### PR TITLE
Add THEREDA Release 2026-01 from June 6, 2026

### DIFF
--- a/database/OtherDatabases/THEREDA_2026-01_PHRQ.dat
+++ b/database/OtherDatabases/THEREDA_2026-01_PHRQ.dat
@@ -1,0 +1,15438 @@
+#########################################
+# Created from the THEREDA thermodynamic database (www.thereda.de) for PHREEQC
+# Generated on: 04-Jun-2026 12:07:42 UTC
+# Exporter script version: 3.1.2
+# Note: The precision of numeric values may be different from what may be justified from experimental data.
+#########################################
+
+SOLUTION_MASTER_SPECIES
+#
+#element   species     alk             gfw     gfw_element
+#
+Alkalinity CO3-2 1 Ca0.5(CO3)0.5 50.05
+E          e-          0.0           0.000           0.000
+U          UO2+2       0.0       270.02771       238.02891
+Sr         Sr+2        0.0           87.62           87.62
+Cm         Cm+3        0.0        247.0704        247.0704
+Zn         Zn+2        0.0          65.409          65.409
+C          CO3-2       2.0         60.0089         12.0107
+Se         SeO4-2      0.0        142.9576           78.96
+K          K+          0.0         39.0983         39.0983
+Cl         Cl-         0.0          35.453          35.453
+Pu         Pu+4       -3.0        244.0628        244.0628
+Tc         TcO4-       0.0        162.9039         98.9063
+S          SO4-2       0.0         96.0626          32.065
+Mg         Mg+2        0.0          24.305          24.305
+O          H2O         0.0        18.01528         15.9994
+P          PO4-3       2.0       94.971362       30.973762
+Am         Am+3        0.0        243.0614        243.0614
+Nd         Nd+3        0.0         144.242         144.242
+Np         Np+4       -3.0        237.0482        237.0482
+Si         Si(OH)4     0.0        96.11486         28.0855
+Al         Al(OH)4-    0.0      95.0108986      26.9815386
+Th         Th+4        0.0       232.03806       232.03806
+Cs         Cs+         0.0     132.9054519     132.9054519
+Cd         Cd+2        0.0         112.411         112.411
+H          H+         -1.0         1.00794         1.00794
+Pb         Pb+2        0.0           207.2           207.2
+Ca         Ca+2        0.0          40.078          40.078
+N          NO3-        0.0         62.0049         14.0067
+Na         Na+         0.0     22.98976928     22.98976928
+H(0)       H2          0.0         2.01588         1.00794
+U(6)       UO2+2       0.0       270.02771       238.02891
+Se(6)      SeO4-2      0.0        142.9576           78.96
+Tc(7)      TcO4-       0.0        162.9039         98.9063
+O(-2)      H2O         0.0        18.01528         15.9994
+Np(4)      Np+4       -3.0        237.0482        237.0482
+H(1)       H+         -1.0         1.00794         1.00794
+O(0)       O2          0.0         31.9988         15.9994
+U(4)       U+4        -3.0       238.02891       238.02891
+Np(5)      NpO2+       0.0         269.047        237.0482
+Se(4)      SeO3-2      1.0        126.9582           78.96
+Tc(4)      TcO(OH)2    0.0       148.92038         98.9063
+C(4)       CO3-2       2.0         60.0089         12.0107
+
+SOLUTION_SPECIES
+
+# ###### Primary Master ########################################################
+e- = e-
+    log_k     0.0
+
+Al(OH)4- = Al(OH)4-
+    log_k     0.0
+
+Am+3 = Am+3
+    log_k     0.0
+
+CO3-2 = CO3-2
+    log_k     0.0
+
+Ca+2 = Ca+2
+    log_k     0.0
+
+Cd+2 = Cd+2
+    log_k     0.0
+
+Cl- = Cl-
+    log_k     0.0
+
+Cm+3 = Cm+3
+    log_k     0.0
+
+Cs+ = Cs+
+    log_k     0.0
+
+H2O = H2O
+    log_k     0.0
+
+H+ = H+
+    log_k     0.0
+
+K+ = K+
+    log_k     0.0
+
+Mg+2 = Mg+2
+    log_k     0.0
+
+NO3- = NO3-
+    log_k     0.0
+
+Na+ = Na+
+    log_k     0.0
+
+Nd+3 = Nd+3
+    log_k     0.0
+
+Np+4 = Np+4
+    log_k     0.0
+
+PO4-3 = PO4-3
+    log_k     0.0
+
+Pb+2 = Pb+2
+    log_k     0.0
+
+Pu+4 = Pu+4
+    log_k     0.0
+
+SO4-2 = SO4-2
+    log_k     0.0
+
+SeO4-2 = SeO4-2
+    log_k     0.0
+
+Si(OH)4 = Si(OH)4
+    log_k     0.0
+
+Sr+2 = Sr+2
+    log_k     0.0
+
+TcO4- = TcO4-
+    log_k     0.0
+
+Th+4 = Th+4
+    log_k     0.0
+
+UO2+2 = UO2+2
+    log_k     0.0
+
+Zn+2 = Zn+2
+    log_k     0.0
+
+
+# ###### Secondary Master ######################################################
+2 H+ + 2 e- = H2
+    # Editor: Bok
+    log_k     -3.1060872355098
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression              -5.29503E+1   0             2.4009753E+3       1.6889231398602E+1   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 353.15 K.
+    # Reference: YOU/BAT1981
+    # Description: Recalculated from equation 2 at page 1 of YOU/BAT1981: ln(x(H2))=-48.1611+55.2845/(T/100K)+16.8893ln(T/100K)
+
+2 H2O + Np+4 = NpO2+ + 4 H+ + e-
+    # Editor: Marquardt
+    log_k     -10.211761368305
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CF
+
+2 H2O = O2 + 4 H+ + 4 e-
+    # Editor: Bok
+    log_k     -85.9938
+    # Evaluation data class: 1, data quality: 1
+    # Reference: BOK/MOO2023
+    # Editor: Moog
+    -analytical_expression      9.54885410999999E+0             1.6987413E-2          -2.863833637E+4     -1.80776363208524E+0           4.867535491E+4              -7.10119E-6 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: BOK/MOO2023
+    # Description: the analytical expression has been formed from the summation of the reactions H2O(l) = O2(g) + H2(g) and O2(g) = O2(aq)
+    # Editor: Moog
+
+SeO4-2 + 2 H+ + 2 e- = SeO3-2 + H2O
+    # Original equation: H2O(l) + H2SeO3(aq) <==> HSeO4<-> + 3 H<+> + 2 EA<->
+    # Editor: Bok
+    log_k     28.038981954418
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CF
+    -analytical_expression       5.1580405926442E+0   0     -9.89769227240657E+3   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+
+4 H+ + TcO4- + 3 e- = TcO(OH)2 + H2O
+    # Original equation: TcO4- + 3 e- + 4 H+  TcO(OH)2(aq) + H2O(l)
+    # Editor: Kiefer
+    log_k     30.171
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GRE/GAO2020
+
+4 H+ + UO2+2 + 2 e- = U+4 + 2 H2O
+    # Description: 4H<+>+UO2<2+>+2e<-> = 2H2O+U<4+>
+    # Editor: Richter
+    log_k     9.038
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Additional reference: GRE/FUG1992
+    # Description: original equation: 4H<+>+UO2<2+>+2e<-> = 2H2O+U<4+>; original value 9.038+-0.041
+
+
+# ###### Product Species #######################################################
+2 H2O + 2 UO2+2 = (UO2)2(OH)2+2 + 2 H+
+    # Editor: Richter
+    log_k     -5.62
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Additional reference: GRE/FUG1992
+
+4 H2O + 3 UO2+2 = (UO2)3(OH)4+2 + 4 H+
+    # Editor: Richter
+    log_k     -11.9
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Additional reference: GRE/FUG1992
+
+5 H2O + 3 UO2+2 = (UO2)3(OH)5+ + 5 H+
+    # Editor: Richter
+    log_k     -15.55
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Additional reference: GRE/FUG1992
+
+7 H2O + 3 UO2+2 = (UO2)3(OH)7- + 7 H+
+    # Editor: Richter
+    log_k     -32.2
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+7 H2O + 4 UO2+2 = (UO2)4(OH)7+ + 7 H+
+    # Editor: Richter
+    log_k     -21.9
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Additional reference: GRE/FUG1992
+
+Al(OH)4- + 2 H+ = Al(OH)2+ + 2 H2O
+    # Description: Recalculated to THEREDA basic species Al(OH)4<->
+    # Original equation: Al<3+> + 2 H2O(l) = Al(OH)2<+> + 2 H<+>
+    # Editor: Miron
+    log_k     12.235203756498
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression                   4.0E-2   0                 3.636E+3   0   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 473.15 K.
+    # Reference: MIR2023
+    # Additional reference: BRO/EKB2016
+
+Al(OH)4- + H+ = Al(OH)3 + H2O
+    # Description: Recalculated to THEREDA basic species Al(OH)4<->
+    # Original equation: Al<3+> + 3 H2O(l) = Al(OH)3<0> + 3 H<+>
+    # Editor: Miron
+    log_k     7.2055408351501
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression                  -7.2E-1   0                 2.363E+3   0   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 473.15 K.
+    # Reference: MIR2023
+    # Additional reference: BRO/EKB2016
+
+Al(OH)4- + 4 H+ = Al+3 + 4 H2O
+    # Editor: Miron
+    log_k     22.868250880429
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression                 -8.74E+0   0                 9.424E+3   0   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 473.15 K.
+    # Reference: MIR2023
+
+Al(OH)4- + 3 H+ = AlOH+2 + 3 H2O
+    # Original equation: Al<3+> + H2O(l) = AlOH<2+> + H<+>
+    # Editor: Miron
+    log_k     17.894460841858
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression                 -3.91E+0   0                 6.501E+3   0   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 473.15 K.
+    # Reference: MIR2023
+    # Additional reference: BRO/EKB2016
+
+Al(OH)4- + 3 H+ + Si(OH)4 = AlSiO(OH)3+2 + 4 H2O
+    # Editor: Miron
+    log_k     20.469751802784
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression                   5.1E-1   0                 5.951E+3   0   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Additional reference: POK/SCH1996
+
+Am+3 + 2 CO3-2 = Am(CO3)2-
+    # Editor: Marquardt
+    log_k     12.9
+    # Evaluation data class: 2, data quality: 1
+    # Reference: GUI/FAN2003
+
+Am+3 + 3 CO3-2 = Am(CO3)3-3
+    # Editor: Marquardt
+    log_k     15.0
+    # Evaluation data class: 2, data quality: 1
+    # Reference: GUI/FAN2003
+
+Am+3 + CO3-2 = Am(CO3)+
+    # Editor: Marquardt
+    log_k     8.0
+    # Evaluation data class: 2, data quality: 1
+    # Reference: GUI/FAN2003
+
+Am+3 + 2 NO3- = Am(NO3)2+
+    # Editor: Kiefer
+    log_k     0.81
+    # Evaluation data class: 2, data quality: 1
+    # Reference: DOS/HAU2026
+
+Am+3 + NO3- = Am(NO3)+2
+    # Editor: Kiefer
+    log_k     1.21
+    # Evaluation data class: 2, data quality: 1
+    # Reference: DOS/HAU2026
+
+Am+3 + 2 H2O = Am(OH)2+ + 2 H+
+    # Editor: Marquardt
+    log_k     -15.1
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+Am+3 + 3 H2O = Am(OH)3 + 3 H+
+    # Editor: Marquardt
+    log_k     -26.2
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Additional reference: NEC/ALT2009
+
+Am+3 + 4 H2O = Am(OH)4- + 4 H+
+    # Editor: Marquardt
+    log_k     -40.7
+    # Evaluation data class: 1, data quality: 3
+    # Reference: NEC/ALT2009
+
+Am+3 + H2O = Am(OH)+2 + H+
+    # Editor: Marquardt
+    log_k     -7.2
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+Am+3 + 2 SO4-2 = Am(SO4)2-
+    # Editor: Marquardt
+    log_k     3.7
+    # Evaluation data class: 2, data quality: 1
+    # Reference: GUI/FAN2003
+
+Am+3 + SO4-2 = Am(SO4)+
+    # Editor: Marquardt
+    log_k     3.3
+    # Evaluation data class: 2, data quality: 1
+    # Reference: GUI/FAN2003
+
+Am+3 + 2 Cl- = AmCl2+
+    # Editor: Marquardt
+    log_k     -0.74
+    # Evaluation data class: 2, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: value calculated from a selected standard potential by NEA
+
+Am+3 + Cl- = AmCl+2
+    # Editor: Marquardt
+    log_k     0.24
+    # Evaluation data class: 2, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: value calculated from a selected standard potential by NEA
+
+CO3-2 + 2 H+ = CO2 + H2O
+    # Description: original value 6.354+-0.020
+    # Original equation: H<+> + HCO3<-> = CO2(0) + H2O(l)
+    # Editor: Freyer
+    log_k     16.679918277137
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      -1.8888689018021E+2   0      1.02112089549859E+4      6.92353118046786E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+CO3-2 + Ca+2 = Ca(CO3)
+    # Editor: Freyer
+    log_k     3.1889983370276
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression     -1.13968023340514E+2   0      4.53995870162831E+3      4.11932166696734E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+Ca+2 + SO4-2 = Ca(SO4)
+    # Editor: Freyer
+    log_k     -0.87055536687055
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression     -1.12528122218741E+1      3.48222566089916E-2   0   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+Am+3 + 2 Ca+2 + 4 H2O = Ca2(Am(OH)4)+3 + 4 H+
+    # Editor: Marquardt
+    log_k     -37.2
+    # Evaluation data class: 2, data quality: 1
+    # Reference: NEC/ALT2009
+    # Additional reference: RAB/ALT2008
+
+2 Ca+2 + Cm+3 + 4 H2O = Ca2(Cm(OH)4)+3 + 4 H+
+    # Editor: Marquardt
+    log_k     -37.2
+    # Evaluation data class: 1, data quality: 1
+    # Reference: NEC/ALT2009
+    # Additional reference: RAB/ALT2008
+
+2 Ca+2 + 4 H2O + Nd+3 = Ca2(Nd(OH)4)+3 + 4 H+
+    # Editor: Marquardt
+    log_k     -37.2
+    # Evaluation data class: 1, data quality: 1
+    # Reference: NEC/ALT2009
+    # Additional reference: RAB/ALT2008
+
+3 Ca+2 + 3 H2O + TcO(OH)2 = Ca3TcO(OH)5+3 + 3 H+
+    # Description: Original log K = -41.65 +- 0.30
+    # Original equation: TcO2 0.6H2O(s) + 3Ca<2+>  + 3.4H2O    Ca3[TcO(OH)5]<3+>  + 3H<+>
+    # Editor: Kiefer
+    log_k     -32.93
+    # Evaluation data class: 1, data quality: 1
+    # Reference: KIE/FEL2025
+    # Additional reference: YAL/GAO2016
+    # Description: Original LOGK298 in YAL/GAO2016: -41.65 +- 0.30 Original reaction: TcO2 0.6H2O(s) + 3Ca<2+>  + 3.4H2O    Ca3[TcO(OH)5]<3+>  + 3H<+> Changed from -32.85 to -32.93 since logK of master species changed
+
+Am+3 + 3 Ca+2 + 6 H2O = Ca3(Am(OH)6)+3 + 6 H+
+    # Editor: Marquardt
+    log_k     -60.7
+    # Evaluation data class: 2, data quality: 1
+    # Reference: NEC/ALT2009
+    # Additional reference: RAB/ALT2008
+
+3 Ca+2 + Cm+3 + 6 H2O = Ca3(Cm(OH)6)+3 + 6 H+
+    # Editor: Marquardt
+    log_k     -60.7
+    # Evaluation data class: 1, data quality: 1
+    # Reference: NEC/ALT2009
+    # Additional reference: RAB/ALT2008
+
+3 Ca+2 + 6 H2O + Nd+3 = Ca3(Nd(OH)6)+3 + 6 H+
+    # Editor: Marquardt
+    log_k     -60.7
+    # Evaluation data class: 1, data quality: 1
+    # Reference: NEC/ALT2009
+    # Additional reference: RAB/ALT2008
+
+3 Ca+2 + 5 H2O + NpO2+ = Ca3(NpO2(OH)5)+2 + 5 H+
+    # Editor: Gaona
+    log_k     -54.79
+    # Evaluation data class: 1, data quality: 1
+    # Reference: FEL/ALT2016
+
+4 Ca+2 + 8 H2O + Np+4 = Ca4(Np(OH)8)+4 + 8 H+
+    # Description: LOGK298 (original reaction): 55.1
+    # Original equation: 4Ca<2+> + Np<4+> + 8OH<->  = Ca4[Np(OH)8]<4+>
+    # Editor: Marquardt
+    log_k     -56.9
+    # Evaluation data class: 1, data quality: 1
+    # Reference: FEL/NEC2010
+
+4 Ca+2 + 8 H2O + Pu+4 = Ca4(Pu(OH)8)+4 + 8 H+
+    # Description: LOGK298 (original reaction): 55.0
+    # Original equation: 4Ca<2+> + Pu<4+> + 8OH<->  =  Ca4[Pu(OH)8]<4+>
+    # Editor: Marquardt
+    log_k     -57.0
+    # Evaluation data class: 1, data quality: 1
+    # Reference: FEL/NEC2010
+    # Description: Application of the chemical model of Th(IV); Pu(IV) complex could not be identified by EXAFS contrary to the Th(IV) complex (and the Zr(IV) complex Ca3[Zr(OH)6]4+) which could be identified and characterized by EXAFS measurements
+
+4 Ca+2 + 8 H2O + Th+4 = Ca4(Th(OH)8)+4 + 8 H+
+    # Description: LOGK298 (original reaction) : 48.5
+    # Original equation: 4Ca<2+> + Th<4+> + 8OH<->  =  Ca4[Th(OH)8]<4+>
+    # Editor: Marquardt
+    log_k     -63.5
+    # Evaluation data class: 1, data quality: 1
+    # Reference: FEL/NEC2010
+
+4 Ca+2 + 8 H2O + U+4 = Ca4(U(OH)8)+4 + 8 H+
+    # Editor: Bok
+    log_k     -59.5
+    # Evaluation data class: 1, data quality: 1
+    # Reference: FEL/NEC2010
+    # Additional reference: YAN/CEV2023
+
+Ca+2 + K+ + SO4-2 = CaK(SO4)+
+    # Editor: Freyer
+    log_k     1.2263399537149
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      4.02197066649232E+0   0     -8.33516857260838E+2   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+Ca+2 + Si(OH)4 = CaSiO(OH)3+ + H+
+    # Editor: Miron
+    log_k     -8.6634579909442
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression   0   0              -2.58301E+3   0   0   0 
+    # Evaluation data class: 3, data quality: 2
+    # Temperature range min - max: 298.15 K - 373.15 K.
+    # Reference: MIR2023
+
+Ca+2 + Si(OH)4 = CaSiO2(OH)2 + 2 H+
+    # Editor: Miron
+    log_k     -19.192990105651
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression   0   0              -5.72239E+3   0   0   0 
+    # Evaluation data class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 373.15 K.
+    # Reference: MIR2023
+
+Am+3 + Ca+2 + 3 H2O = Ca(Am(OH)3)+2 + 3 H+
+    # Editor: Marquardt
+    log_k     -26.3
+    # Evaluation data class: 2, data quality: 1
+    # Reference: NEC/ALT2009
+    # Additional reference: RAB/ALT2008
+
+Ca+2 + Cm+3 + 3 H2O = Ca(Cm(OH)3)+2 + 3 H+
+    # Editor: Marquardt
+    log_k     -26.3
+    # Evaluation data class: 1, data quality: 1
+    # Reference: NEC/ALT2009
+    # Additional reference: RAB/ALT2008
+
+Ca+2 + 3 H2O + Nd+3 = Ca(Nd(OH)3)+2 + 3 H+
+    # Editor: Marquardt
+    log_k     -26.3
+    # Evaluation data class: 1, data quality: 1
+    # Reference: NEC/ALT2009
+    # Additional reference: RAB/ALT2008
+
+Ca+2 + 2 H2O + NpO2+ = Ca(NpO2(OH)2)+ + 2 H+
+    # Editor: Gaona
+    log_k     -20.74
+    # Evaluation data class: 1, data quality: 1
+    # Reference: FEL/ALT2016
+
+2 CO3-2 + Cd+2 = Cd(CO3)2-2
+    # Editor: Moog
+    log_k     6.38
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG2024
+
+CO3-2 + Cd+2 = Cd(CO3)
+    # Editor: Moog
+    log_k     4.23
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG2024
+
+CO3-2 + Cd+2 + H+ = Cd(HCO3)+
+    # Original equation: Cd<2+>+HCO3<->=CdHCO3<+>
+    # Editor: Moog
+    log_k     12.69
+    # Evaluation data class: 1, data quality: 1
+    # Reference: STE/GAN1984
+    # Description: Original LOGK298 in [STE/GAN1984] = 2.36 +- 0.1
+
+Cd+2 + 2 H2O = Cd(OH)2 + 2 H+
+    # Original equation: Cd<2+>+2OH<->=Cd(OH)2
+    # Editor: Moog
+    log_k     -20.51
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG2024
+    # Description: Original LOGK298 in [HAG2004] = 7.49
+
+Cd+2 + 4 H2O = Cd(OH)4-2 + 4 H+
+    # Original equation: Cd<2+>+4OH<->=Cd(OH)4<2+>
+    # Editor: Moog
+    log_k     -46.49
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG2024
+    # Description: Original LOGK298 in [HAG2004] = 9.51
+
+Cd+2 + H2O = Cd(OH)+ + H+
+    # Original equation: Cd<2+>+OH<->=CdOH<+>
+    # Editor: Moog
+    log_k     -9.84
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG2024
+    # Description: Original LOGK298 in [HAG2004] = 4.16
+
+Cd+2 + Cl- + H2O = CdCl(OH) + H+
+    # Original equation: Cd<2+>+Cl<->+OH<->=CdClOH<0>
+    # Editor: Moog
+    log_k     -8.2
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GAY/HAA1960
+    # Description: Original LOGK298 in [GAY/HAA1960] = 5.8
+
+2 CO3-2 + Cm+3 = Cm(CO3)2-
+    # Editor: Marquardt
+    log_k     12.9
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: LogK298 was deduced from experimental Am and Cm data combined in an overall Am-Cm-model!
+
+3 CO3-2 + Cm+3 = Cm(CO3)3-3
+    # Editor: Marquardt
+    log_k     15.0
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: LogK298 was deduced from experimental Am and Cm data combined in an overall Am-Cm-model!
+
+4 CO3-2 + Cm+3 = Cm(CO3)4-5
+    # Editor: Marquardt
+    log_k     13.0
+    # Evaluation data class: 1, data quality: 3
+    # Reference: NEC/FAN1998
+    # Additional reference: FAN/KON1999
+
+CO3-2 + Cm+3 = Cm(CO3)+
+    # Editor: Marquardt
+    log_k     8.0
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: LogK298 was deduced from experimental Am and Cm data combined in an overall Am-Cm-model!
+
+Cm+3 + 2 NO3- = Cm(NO3)2+
+    # Editor: Kiefer
+    log_k     0.81
+    # Evaluation data class: 2, data quality: 1
+    # Reference: DOS/HAU2026
+
+Cm+3 + NO3- = Cm(NO3)+2
+    # Editor: Kiefer
+    log_k     1.21
+    # Evaluation data class: 2, data quality: 1
+    # Reference: DOS/HAU2026
+
+Cm+3 + 2 H2O = Cm(OH)2+ + 2 H+
+    # Editor: Marquardt
+    log_k     -15.1
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: Logk298 was deduced from experimental Am and Cm data for a overall Am-Cm-model!
+
+Cm+3 + 3 H2O = Cm(OH)3 + 3 H+
+    # Editor: Marquardt
+    log_k     -26.2
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: Logk298 was deduced from experimental Am and Cm data for a overall Am-Cm-model!
+
+Cm+3 + 4 H2O = Cm(OH)4- + 4 H+
+    # Description: Species selected analogous to Am(III).
+    # Editor: Kiefer
+    log_k     -40.7
+    # Evaluation data class: 2, data quality: 3
+    # Reference: NEC/ALT2009
+    # Description: Value analogous to Am(III).
+
+Cm+3 + H2O = Cm(OH)+2 + H+
+    # Editor: Marquardt
+    log_k     -7.2
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: Logk298 was deduced from experimental Am and Cm data for a overall Am-Cm-model!
+
+Cm+3 + 2 SO4-2 = Cm(SO4)2-
+    # Editor: Marquardt
+    log_k     3.7
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Additional reference: NEC/FAN1998
+    # Description: Logk298 was deduced from experimental Am and Cm data for a overall Am-Cm-model!
+
+Cm+3 + SO4-2 = Cm(SO4)+
+    # Editor: Marquardt
+    log_k     3.3
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: Logk298 was deduced from experimental Am and Cm data for a overall Am-Cm-model!
+
+2 Cl- + Cm+3 = CmCl2+
+    # Editor: Marquardt
+    log_k     -0.74
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Additional reference: KON/FAN1997
+
+Cl- + Cm+3 = CmCl+2
+    # Editor: Marquardt
+    log_k     0.24
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Additional reference: KON/FAN1997
+
+2 H+ + PO4-3 = H2PO4-
+    # Description: original equation: H<+>+HPO4<2->=H2PO4<->, original value 7.212+-0.013
+    # Editor: Moog
+    log_k     19.562
+    # Evaluation data class: 0, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: original equation: H<+> + HPO4<2->=H2PO4<->, original value 7.212+-0.013
+    -analytical_expression      1.63735795906448E+1   0      9.50627545049264E+2   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+
+2 H+ + SeO3-2 = H2SeO3
+    # Original equation: H2SeO3<0> <=> H<+> + HSeO3<->
+    # Editor: Bok
+    log_k     11.24
+    # Evaluation data class: 1, data quality: 1
+    # Reference: SEB/POT2001
+    # Additional reference: BOK2021
+    # Description: Recalculated from original equation: H2SeO3<0> + H2O(l) <=> HSeO3<-> + H<+> pKs1 = 2.70  0.06 and HSeO3<-> + H2O(l) <=> SeO3<2-> + H<+> pKs2 = 8.54  0.04
+
+3 H+ + PO4-3 = H3PO4
+    # Description: original equation: H<+>+H2PO4<->=H3PO4<0>, original value 8480+-600
+    # Editor: Moog
+    log_k     21.702
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: original equation: H<+>+H2PO4<->=H3PO4<0>, original value 2.140+-0.030
+
+CO3-2 + H+ = HCO3-
+    # Editor: Freyer
+    log_k     10.326921536195
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression     -8.33007581754366E+1   0      4.82111534457023E+3      3.13031451079439E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+H+ + PO4-3 = HPO4-2
+    # Editor: Moog
+    log_k     12.35
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: Masterspezies in NEA-TDB
+    -analytical_expression      9.79218096104312E+0   0      7.62613746464942E+2   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+
+H+ + SO4-2 = HSO4-
+    # Editor: Freyer
+    log_k     1.9640748286074
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -analytical_expression      -5.6244628148478E+2     -2.47784822406183E-1      1.32616652577497E+4      2.35961961994106E+2   0      1.11763774481735E-4 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+H+ + SeO3-2 = HSeO3-
+    # Original equation: HSeO3<-> <=> H<+> + SeO3<2->
+    # Editor: Bok
+    log_k     8.54
+    # Evaluation data class: 1, data quality: 1
+    # Reference: SEB/POT2001
+    # Additional reference: BOK2021
+
+K+ + Mg+2 + SO4-2 = KMg(SO4)+
+    # Editor: Freyer
+    log_k     -2.5402756184094
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      1.56700155837363E+1   0     -5.42939923283823E+3   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+2 CO3-2 + Mg+2 = Mg(CO3)2-2
+    # Editor: Freyer
+    log_k     3.8436997977864
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression   0   0      1.14600047302392E+3   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+CO3-2 + Mg+2 = Mg(CO3)
+    # Editor: Freyer
+    log_k     2.8766779710516
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression     -8.36392305120453E+1   0      3.25699184572548E+3      3.05491611040952E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+H2O + Mg+2 = Mg(OH)+ + H+
+    # Editor: Freyer
+    log_k     -11.695088358998
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      2.87024490777797E+2   0     -2.31939255794562E+4     -9.60660540381262E+1      1.27402450034304E+6      2.75651244133505E-5 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+3 CO3-2 + 2 Mg+2 + UO2+2 = Mg2(UO2(CO3)3)
+    # Editor: Richter
+    log_k     27.1
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GRE/GAO2020
+    # Description: no Pitzer parameters available, existence of this species is clearly acknowledged
+
+4 H2O + 3 Mg+2 = Mg3(OH)4+2 + 4 H+
+    # Editor: Freyer
+    log_k     -39.304546279905
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      5.79229902833183E+1     -1.39298124206688E-1     -1.98821562259129E+4   0   0      1.23622539511375E-4 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+3 H2O + 3 Mg+2 + TcO(OH)2 = Mg3TcO(OH)5+3 + 3 H+
+    # Description: Original LOGK298: -40.32 +- 0.5
+    # Original equation: TcO20.6H2O(s) + 3Mg<2+> + 3.4H2O    Mg3[TcO(OH)5]< 3+> + 3H<+>
+    # Editor: Kiefer
+    log_k     -31.6
+    # Evaluation data class: 1, data quality: 1
+    # Reference: KIE/FEL2025
+    # Additional reference: YAL/GAO2016
+    # Description: Original LOGK298 in YAL/GAO2016: -40.32 +- 0.50 Original reaction: TcO2 0.6H2O(s) + 3Mg<2+>  + 3.4H2O    Mg3[TcO(OH)5]<3+>  + 3H<+> Changed from -31.52 to -31.60 since logK of master species changed
+
+Mg+2 + Si(OH)4 = MgSiO(OH)3+ + H+
+    # Editor: Miron
+    log_k     -8.4734529599195
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression   0   0              -2.52636E+3   0   0   0 
+    # Evaluation data class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 373.15 K.
+    # Reference: MIR2023
+
+Mg+2 + Si(OH)4 = MgSiO2(OH)2 + 2 H+
+    # Editor: Miron
+    log_k     -17.672983397619
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression   0   0               -5.2692E+3   0   0   0 
+    # Evaluation data class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 373.15 K.
+    # Reference: MIR2023
+
+Am+3 + 2 H2O + Mg+2 + NO3- = Mg(Am(NO3)(OH)2)+2 + 2 H+
+    # Editor: Kiefer
+    log_k     -15.6
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HER/GAO2015
+
+Am+3 + H2O + Mg+2 + NO3- = Mg(Am(NO3)(OH))+3 + H+
+    # Editor: Kiefer
+    log_k     -6.4
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HER/GAO2015
+
+Cm+3 + 2 H2O + Mg+2 + NO3- = Mg(Cm(NO3)(OH)2)+2 + 2 H+
+    # Editor: Kiefer
+    log_k     -15.6
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HER/GAO2015
+
+Cm+3 + H2O + Mg+2 + NO3- = Mg(Cm(NO3)(OH))+3 + H+
+    # Editor: Kiefer
+    log_k     -6.4
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HER/GAO2015
+
+2 H2O + Mg+2 + NO3- + Nd+3 = Mg(Nd(NO3)(OH)2)+2 + 2 H+
+    # Editor: Kiefer
+    log_k     -15.6
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HER/GAO2015
+
+H2O + Mg+2 + NO3- + Nd+3 = Mg(Nd(NO3)(OH))+3 + H+
+    # Editor: Kiefer
+    log_k     -6.4
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HER/GAO2015
+
+2 NO3- + Nd+3 = Nd(NO3)2+
+    # Editor: Kiefer
+    log_k     0.81
+    # Evaluation data class: 2, data quality: 1
+    # Reference: DOS/HAU2026
+
+NO3- + Nd+3 = Nd(NO3)+2
+    # Editor: Kiefer
+    log_k     1.21
+    # Evaluation data class: 2, data quality: 1
+    # Reference: DOS/HAU2026
+
+2 H2O + Nd+3 = Nd(OH)2+ + 2 H+
+    # Editor: Marquardt
+    log_k     -15.7
+    # Evaluation data class: 1, data quality: 1
+    # Reference: NEC/ALT2009
+
+3 H2O + Nd+3 = Nd(OH)3 + 3 H+
+    # Editor: Marquardt
+    log_k     -26.2
+    # Evaluation data class: 2, data quality: 1
+    # Reference: NEC/ALT2009
+
+4 H2O + Nd+3 = Nd(OH)4- + 4 H+
+    # Editor: Marquardt
+    log_k     -40.7
+    # Evaluation data class: 2, data quality: 1
+    # Reference: NEC/ALT2009
+
+H2O + Nd+3 = Nd(OH)+2 + H+
+    # Editor: Marquardt
+    log_k     -7.4
+    # Evaluation data class: 1, data quality: 1
+    # Reference: NEC/ALT2009
+
+2 Cl- + Nd+3 = NdCl2+
+    # Editor: Marquardt
+    log_k     -0.74
+    # Evaluation data class: 2, data quality: 1
+    # Reference: NEC/ALT2009
+
+Cl- + Nd+3 = NdCl+2
+    # Editor: Marquardt
+    log_k     0.24
+    # Evaluation data class: 2, data quality: 1
+    # Reference: NEC/ALT2009
+
+5 CO3-2 + Np+4 = Np(CO3)5-6
+    # Description: LOGK298 (original reaction): -1.070
+    # Original equation: Np(CO3)4<4-> + CO3<2-> = Np(CO3)5<6->
+    # Editor: Marquardt
+    log_k     35.61
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+2 CO3-2 + 2 H2O + Np+4 = Np(OH)2(CO3)2-2 + 2 H+
+    # Description: LOGK295 = -4.44 for the original reaction
+    # Original equation: NpO2(am) + 2HCO3<-> = Np(OH)2(CO3)2<2->
+    # Editor: Marquardt
+    log_k     16.95
+    # Evaluation data class: 1, data quality: 3
+    # Reference: RAI/HES1999
+
+2 H2O + Np+4 = Np(OH)2+2 + 2 H+
+    # Editor: Marquardt
+    log_k     0.35
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+3 H2O + Np+4 = Np(OH)3+ + 3 H+
+    # Description: LOGK298 = 39.2 for the original reaction
+    # Original equation: Np<4+> + 3OH<->  =  Np(OH)3<+>
+    # Editor: Marquardt
+    log_k     -2.8
+    # Evaluation data class: 3, data quality: 1
+    # Reference: NEC/KIM2001
+    # Description: Estimated value from correlations and with electrostatic model by NEC/KIM2000
+
+4 H2O + Np+4 = Np(OH)4 + 4 H+
+    # Description: LOGK298 = 47.7 for the original reaction
+    # Original equation: Np<4+> + 4OH<->  =  Np(OH)4<0>
+    # Editor: Marquardt
+    log_k     -8.3
+    # Evaluation data class: 1, data quality: 2
+    # Reference: NEC/KIM2001
+
+H2O + Np+4 = Np(OH)+3 + H+
+    # Editor: Marquardt
+    log_k     0.55
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+Cl- + Np+4 = NpCl+3
+    # Description: Pitzer parameters are not available or this species. However, the lack of these ion interaction parameters has no effect on calculations performed under repository-relevant pH conditions (near-neutral to alkaline)
+    # Editor: Marquardt
+    log_k     1.5
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+2 CO3-2 + NpO2+ = NpO2(CO3)2-3
+    # Original equation: NpO2CO3<-> + CO2<2-> = NpO2(CO3)2<3-> log K = 1.572 +- 0.083
+    # Editor: Marquardt
+    log_k     6.534
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: Original equation: NpO2CO3<-> + CO2<2-> = NpO2(CO3)2<3-> log K = 1.572 +- 0.083
+
+3 CO3-2 + NpO2+ = NpO2(CO3)3-5
+    # Original equation: NpO2(CO3)2<3-> + CO2<2-> = NpO2(CO3)3<5-> log K = -1.034 +- 0.110
+    # Editor: Marquardt
+    log_k     5.5
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: Original equation: NpO2(CO3)2<3-> + CO2<2-> = NpO2(CO3)3<5-> log K = -1.034 +- 0.110
+
+CO3-2 + NpO2+ = NpO2(CO3)-
+    # Editor: Marquardt
+    log_k     4.962
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+2 H2O + NpO2+ = NpO2(OH)2- + 2 H+
+    # Editor: Marquardt
+    log_k     -23.6
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+H2O + NpO2+ = NpO2(OH) + H+
+    # Editor: Marquardt
+    log_k     -11.3
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+Cl- + NpO2+ = NpO2Cl
+    # Editor: Gaona
+    log_k     -1.4
+    # Evaluation data class: 1, data quality: 1
+    # Reference: FEL/ALT2016
+
+H2O = OH- + H+
+    # Editor: Freyer
+    log_k     -14.001143764528
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      1.29009808150812E+3      4.40399478710301E-1     -5.10798722349926E+4     -5.12890593300859E+2      1.78136737155914E+6     -1.68816055186552E-4 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 523.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+2 H2O + Pb+2 = Pb(OH)2 + 2 H+
+    # Description: Applicability for calculations for high-saline solutions to be determined
+    # Editor: Moog
+    log_k     -16.92
+    # Evaluation data class: 1, data quality: 1
+    # Reference: MOO2022
+
+3 H2O + Pb+2 = Pb(OH)3- + 3 H+
+    # Description: Applicability for calculations for high-saline solutions to be determined
+    # Editor: Moog
+    log_k     -28.2
+    # Evaluation data class: 1, data quality: 1
+    # Reference: MOO2022
+
+H2O + Pb+2 = Pb(OH)+ + H+
+    # Description: Applicability for calculations for high-saline solutions to be determined
+    # Editor: Moog
+    log_k     -7.23
+    # Evaluation data class: 1, data quality: 1
+    # Reference: MOO2022
+
+Pb+2 + 2 SO4-2 = Pb(SO4)2-2
+    # Editor: Moog
+    log_k     3.134
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG1999
+
+2 Cl- + Pb+2 = PbCl2
+    # Editor: Moog
+    log_k     2.225
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG1999
+    # Description: Original value (p.68): K = 168 +/- 3, hence logK = 2.225 +/- 0.008 (THEREDA)
+
+3 Cl- + Pb+2 = PbCl3-
+    # Editor: Moog
+    log_k     1.811
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG1999
+    # Description: Original value (p.68): K = 64.7 +/- 1, hence logK = 1.811 +/- 0.007 (THEREDA)
+
+4 Cl- + Pb+2 = PbCl4-2
+    # Editor: Moog
+    log_k     0.041
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG1999
+    # Description: Original value (p. 68): K = 1.1 +/- 0.02, hence logK = 0.041 +/- 0.008 (THEREDA)
+
+Cl- + Pb+2 = PbCl+
+    # Editor: Moog
+    log_k     1.481
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG1999
+    # Description: Original value (p. 68): K = 30.3 +/- 0.3, hence logK = 1.481 +/- 0.004 (THEREDA)
+
+Pb+2 + SO4-2 = PbSO4
+    # Editor: Moog
+    log_k     2.776
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG1999
+
+4 CO3-2 + Pu+4 = Pu(CO3)4-4
+    # Editor: Marquardt
+    log_k     37.0
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+5 CO3-2 + Pu+4 = Pu(CO3)5-6
+    # Editor: Marquardt
+    log_k     35.65
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+2 CO3-2 + 2 H2O + Pu+4 = Pu(OH)2(CO3)2-2 + 2 H+
+    # Original equation: Pu<4+> + 2 CO2<2-> + 2 OH<-> = Pu(OH)2(CO3)2<2->; log K = 44.76; RAI/HES1999
+    # Editor: Marquardt
+    log_k     18.24
+    # Evaluation data class: 1, data quality: 3
+    # Reference: RAI/HES1999a
+    # Description: Simplified chemical model according to RAI/HES1999 Original reaction: Pu<4+> + 2 CO2<2-> + 2 OH<-> = Pu(OH)2(CO3)2<2->; log K = 44.76; RAI/HES1999
+
+2 H2O + Pu+4 = Pu(OH)2+2 + 2 H+
+    # Editor: Marquardt
+    log_k     0.6
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+3 H2O + Pu+4 = Pu(OH)3+ + 3 H+
+    # Editor: Marquardt
+    log_k     -2.3
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+4 H2O + Pu+4 = Pu(OH)4 + 4 H+
+    # Editor: Marquardt
+    log_k     -8.5
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+H2O + Pu+4 = Pu(OH)+3 + H+
+    # Editor: Marquardt
+    log_k     0.6
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+Pu+4 + 2 SO4-2 = Pu(SO4)2
+    # Original equation: 2 HSO4<-> + Pu<4+> = 2 H<+> + Pu(SO4)2<0>; log K = 7.180 +- 0.320; (GUI/FAN2003)
+    # Editor: Marquardt
+    log_k     11.11
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: 2 HSO4<-> + Pu<4+> = 2 H<+> + Pu(SO4)2<0>; log K = 7.180 +- 0.320; (GUI/FAN2003); Recalculated considering: H+ + SO4-2 = HSO4- logK = 1.9641 [Thereda]
+
+Pu+4 + SO4-2 = Pu(SO4)+2
+    # Original equation: HSO4<-> + Pu<4+> --> H<+> + Pu(SO4)<2+>; logK=4.91 (GUI/FAN2003)
+    # Editor: Marquardt
+    log_k     6.8741
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: Original reaction: HSO4<-> + Pu<4+> --> H<+> + Pu(SO4)<2+>; logK=4.91 (GUI/FAN2003); Recalculated considering: H+ + SO4-2 = HSO4- logK = 1.9641 [THEREDA]
+
+Cl- + Pu+4 = PuCl+3
+    # Description: No Pitzer parameters have been selected, because there are no experimental data available.The lack of these ion interaction parameters has no effect on calculations performed under repository-relevant pH conditions (near-neutral to alkaline).
+    # Editor: Marquardt
+    log_k     1.8
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+4 Si(OH)4 = Si4O8(OH)4-4 + 4 H2O + 4 H+
+    # Editor: Miron
+    log_k     -37.699090632134
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression              1.800373E+2   0              -1.38429E+4     -6.92307898277601E+1   0   0 
+    # Evaluation data class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+
+Si(OH)4 = SiO(OH)3- + H+
+    # Editor: Miron
+    log_k     -9.8334372217531
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression               4.50097E+1   0              -3.58254E+3     -1.73078874202102E+1   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 573.15 K.
+    # Reference: MIR2023
+
+Si(OH)4 = SiO2(OH)2-2 + 2 H+
+    # Editor: Miron
+    log_k     -23.193058968965
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression               1.03798E+2   0              -7.94213E+3     -4.05559378116246E+1   0   0 
+    # Evaluation data class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+
+2 H+ + 2 TcO(OH)2 = Tc2O3+2 + 3 H2O
+    # Description: Original log K = -4.45 +- 0.41
+    # Original equation: 2TcO2 0.6H2O(s) + 2H<+>  Tc2O3<2+> + 2.2H2O 
+    # Editor: Kiefer
+    log_k     12.99
+    # Evaluation data class: 1, data quality: 1
+    # Reference: KIE/FEL2025
+    # Additional reference: GRE/GAO2020
+    # Description: Original lOGK298: 12.99 +- 0.41 Original reaction: 2TcO(OH)2(aq) + 2H<+>  Tc2O3<2+> + 3H2O (KIE/FEL2025) Original reaction: 2TcO(OH)2(aq) + 2H<+>  Tc2O2(OH)2<2+> + 2H2O (GRE/GAO2020)
+
+H2O + TcO(OH)2 = TcO(OH)3- + H+
+    # Editor: Kiefer
+    log_k     -10.5
+    # Evaluation data class: 1, data quality: 1
+    # Reference: KIE/FEL2025
+
+5 CO3-2 + Th+4 = Th(CO3)5-6
+    # Original equation: ThO2(am) + 4H<+> + 5CO3<2-> = Th(CO3)5<6-> + 2H2O; logK = 37.6; FEL/RAI1997
+    # Editor: Marquardt
+    log_k     29.1
+    # Evaluation data class: 1, data quality: 3
+    # Reference: FEL/RAI1997
+    # Additional reference: MAR/GAO2014
+    # Description: Simplified chemical model according to FEL/RAI1997 ThO2(am) + 4H<+> + 5CO3<2-> = Th(CO3)5<6-> + 2H2O; log K = 37.6; FEL/RAI1997 or Th(OH)4(am) + 5CO3<2-> = Th(CO)5<6-> + 4 OH<->; log K = -18.4; MAR/GAO2014
+
+CO3-2 + 3 H2O + Th+4 = Th(OH)3(CO3)- + 3 H+
+    # Original equation: ThO2(am) + H<+> + H2O + CO3<2-> = Th(OH)3CO~ logK = 6.78; FEL/RAI1997
+    # Editor: Marquardt
+    log_k     -1.72
+    # Evaluation data class: 1, data quality: 3
+    # Reference: MAR/GAO2014
+    # Additional reference: FEL/RAI1997
+    # Description: Original reaction: ThO2(am) + H<+> + H2O + CO3<2-> = Th(OH)3(CO3)<-> logK = 6.78; FEL/RAI1997 Simplified chemical model according to FEL/RAI1997 or Th(OH)4(am) + CO3<2->  =  Th(OH)3(CO3)<-> + OH<->; log K = -7.22, MAR/GAO2014
+
+4 H2O + Th+4 = Th(OH)4 + 4 H+
+    # Editor: Marquardt
+    log_k     -17.4
+    # Evaluation data class: 1, data quality: 1
+    # Reference: RAN/FUG2008
+
+4 CO3-2 + U+4 = U(CO3)4-4
+    # Original equation: U(CO3)5<6-> = U(CO3)4<4-> + CO3<2->
+    # Editor: Richter
+    log_k     35.12
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Additional reference: GRE/FUG1992
+    # Description: original equation: U(CO3)5<6-> = U(CO3)4<4-> + CO3<2->; original value 1.120+-0.250
+
+5 CO3-2 + U+4 = U(CO3)5-6
+    # Original equation: UO2(am)+5CO3<2->+4H<+> = U(CO3)5<6->+2H2O
+    # Editor: Richter
+    log_k     32.35
+    # Evaluation data class: 1, data quality: 3
+    # Reference: RAI/FEL1998
+    # Description: value chosen by [NEC/FAN2001] (also in THEREDA) by reason of consistency with correspondent Pitzer parameters (and not the value of [GUI/FAN2003]),  original reaction UO2(am)+5CO3<2->+4H<+> = U(CO3)5<6->+2H2O, logK=33.8
+
+2 H+ + PO4-3 + U+4 = U(H2PO4)+3
+    # Original equation: U<4+> + H2PO4<-> = U(H2PO4)<3+>
+    # Editor: Bok
+    log_k     26.362
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GRE/GAO2020
+    # Description: original equation: U<4+> + H2PO4<-> = U(H2PO4)<3+>, original value 6.800  0.700; no Pitzer parameters available, but species is necessary and important for modeling
+
+2 CO3-2 + 2 H2O + U+4 = U(OH)2(CO3)2-2 + 2 H+
+    # Original equation: UO2(am) + 2 HCO3<-> = U(OH)2(CO3)2<2->
+    # Editor: Richter
+    log_k     14.36
+    # Evaluation data class: 1, data quality: 3
+    # Reference: NEC/FAN2001
+    # Additional reference: RAI/FEL1998
+    # Description: original reaction: UO2(am) + 2 HCO3<-> = U(OH)2(CO3)2<2-> logK=-4.8; no other data for ternary complexes available, therefore data entry despite of deficiencies in [RAI/FEL1998]; uncertainty estimated by [NEC/FAN2001]
+
+2 H2O + U+4 = U(OH)2+2 + 2 H+
+    # Original equation: U<4+> + 2OH<-> = U(OH)2<2+>
+    # Editor: Richter
+    log_k     -1.9
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GRE/GAO2020
+    # Additional reference: YAN/CEV2023
+
+3 H2O + U+4 = U(OH)3+ + 3 H+
+    # Editor: Richter
+    log_k     -5.2
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GRE/GAO2020
+    # Additional reference: YAN/CEV2023
+
+4 H2O + U+4 = U(OH)4 + 4 H+
+    # Original equation: 4OH<-> + U<4+> = U(OH)4<0>
+    # Editor: Richter
+    log_k     -10.0
+    # Evaluation data class: 1, data quality: 3
+    # Reference: GUI/FAN2003
+    # Additional reference: NEC/KIM2001
+    # Description: original equation: 4OH<->+U<4+> = U(OH)4<0>; original value 46.000+-1.400; necessary for a wide pH range to describe the solubility; questionable whether the based measured metal concentrations (<10E-8M) come from mononuclear species
+
+H2O + U+4 = U(OH)+3 + H+
+    # Editor: Richter
+    log_k     -0.54
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Additional reference: GRE/FUG1992
+
+2 SO4-2 + U+4 = U(SO4)2
+    # Editor: Richter
+    log_k     11.7
+    # Evaluation data class: 2, data quality: 3
+    # Reference: RAI/RAO1999
+    # Description: assumed to be identical with value fr the corresponding Np(IV) species; for THEREDA selected from reason of consistency with Pitzer parameters of [RAI/RAO1999]
+
+SO4-2 + U+4 = U(SO4)+2
+    # Editor: Richter
+    log_k     9.0
+    # Evaluation data class: 2, data quality: 3
+    # Reference: RAI/RAO1999
+    # Description: assumed to be identical with value fr the corresponding Np(IV) species; for THEREDA selected from reason of consistency with Pitzer parameters of [RAI/RAO1999]
+
+2 CO3-2 + UO2+2 = UO2(CO3)2-2
+    # Editor: Richter
+    log_k     16.61
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+3 CO3-2 + UO2+2 = UO2(CO3)3-4
+    # Editor: Richter
+    log_k     21.84
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+CO3-2 + UO2+2 = UO2(CO3)
+    # Editor: Richter
+    log_k     9.94
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+5 H+ + 2 PO4-3 + UO2+2 = UO2(H2PO4)(H3PO4)+
+    # Original equation: 2H3PO4<0> + UO2<2+> = H<+> + UO2(H2PO4)(H3PO4)<+>
+    # Editor: Richter
+    log_k     45.054
+    # Evaluation data class: 1, data quality: 3
+    # Reference: GUI/FAN2003
+    # Description: original reaction: 2H3PO4<0> + UO2<2+> = H<+> + UO2(H2PO4)(H3PO4)<+>, original value 1.650+-0.110; no Pitzer parameters available, but species is necessary and important for modeling
+
+4 H+ + 2 PO4-3 + UO2+2 = UO2(H2PO4)2
+    # Original equation: 2H3PO4<0> + UO2<2+> = 2H+ + UO2(H2PO4)2<0>
+    # Editor: Richter
+    log_k     43.044
+    # Evaluation data class: 1, data quality: 3
+    # Reference: GUI/FAN2003
+    # Description: original equation: 2H3PO4<0> + UO2<2+> = 2H+ + UO2(H2PO4)2<0>, original value 0.640+-0.110; no Pitzer parameters available, but species is necessary and important for modeling
+
+2 H+ + PO4-3 + UO2+2 = UO2(H2PO4)+
+    # Original equation: H3PO4<0> + UO2<2+> = H<+> + UO2H2PO4<+>
+    # Editor: Richter
+    log_k     22.822
+    # Evaluation data class: 1, data quality: 3
+    # Reference: GUI/FAN2003
+    # Description: original equation: H3PO4<0>+UO2<2+>=H<+>+UO2H2PO4<+>, original value 1.120+-0.060; no Pitzer parameters available, but species is necessary and important for modeling
+
+3 H+ + PO4-3 + UO2+2 = UO2(H3PO4)+2
+    # Description: currently no Pitzer parameters available but species nevertheless necessary for modelling
+    # Original equation: H3PO4<0> + UO2<2+> = UO2H3PO4<2+>
+    # Editor: Richter
+    log_k     22.462
+    # Evaluation data class: 1, data quality: 3
+    # Reference: GUI/FAN2003
+    # Description: original equation: H3PO4<0> + UO2<2+> = UO2H3PO4<2+>, original value 0.760+-0.150; no Pitzer parameters available, but species is necessary and important for modeling
+
+H+ + PO4-3 + UO2+2 = UO2(HPO4)
+    # Description: currently no Pitzer parameters available but species nevertheless necessary for modelling
+    # Original equation: HPO4<2-> + UO2<2+> = UO2(HPO4)<0>
+    # Editor: Richter
+    log_k     19.59
+    # Evaluation data class: 1, data quality: 3
+    # Reference: GUI/FAN2003
+    # Description: original equation: HPO4<2-> + UO2<2+> = UO2(HPO4)<0>, original value 7.240+-0.260; no Pitzer parameters available, but species is necessary and important for modeling
+
+2 H2O + UO2+2 = UO2(OH)2 + 2 H+
+    # Editor: Richter
+    log_k     -12.15
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Additional reference: GRE/FUG1992
+
+3 H2O + UO2+2 = UO2(OH)3- + 3 H+
+    # Editor: Richter
+    log_k     -20.7
+    # Evaluation data class: 1, data quality: 1
+    # Reference: ALT/YAL2017
+
+4 H2O + UO2+2 = UO2(OH)4-2 + 4 H+
+    # Editor: Richter
+    log_k     -31.9
+    # Evaluation data class: 1, data quality: 1
+    # Reference: ALT/YAL2017
+    # Description: in [ALT/BRE2004] with -31.92+-0.33; from solubility data [NEC/ALT2003a] (contribution to proceeding, value of logK only at the resp. poster), for consistency reasons different from the value of [GUI/FAN2003] (-32.40+-0.68)
+
+H2O + UO2+2 = UO2(OH)+ + H+
+    # Editor: Richter
+    log_k     -5.25
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+PO4-3 + UO2+2 = UO2(PO4)-
+    # Description: currently no Pitzer parameters available but species nevertheless necessary for modelling
+    # Editor: Richter
+    log_k     13.23
+    # Evaluation data class: 1, data quality: 3
+    # Reference: GUI/FAN2003
+    # Description: no Pitzer parameters available, but species is necessary and important for modeling
+
+2 SO4-2 + UO2+2 = UO2(SO4)2-2
+    # Editor: Richter
+    log_k     4.14
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+SO4-2 + UO2+2 = UO2(SO4)
+    # Editor: Richter
+    log_k     3.15
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+Si(OH)4 + UO2+2 = UO2(SiO(OH)3)+ + H+
+    # Description: currently no Pitzer parameters available but species nevertheless necessary for modelling
+    # Editor: Richter
+    log_k     -1.84
+    # Evaluation data class: 1, data quality: 3
+    # Reference: GUI/FAN2003
+    # Description: no Pitzer parameters available, but species is necessary and important for modeling
+
+2 CO3-2 + Zn+2 = Zn(CO3)2-2
+    # Editor: Moog
+    log_k     4.75
+    # Evaluation data class: 1, data quality: 2
+    # Reference: HAG2022
+
+CO3-2 + H+ + Zn+2 = Zn(HCO3)+
+    # Original equation: Zn<2+> + HCO3<->= Zn(HCO3)<+> (logK = 1.5 +- 0.2)
+    # Editor: Moog
+    log_k     11.83
+    # Evaluation data class: 1, data quality: 2
+    # Reference: HAG2022
+
+2 H2O + Zn+2 = Zn(OH)2 + 2 H+
+    # Original equation: Zn<2+> + 2OH<->= Zn(OH)2<0>
+    # Editor: Moog
+    log_k     -17.0
+    # Evaluation data class: 1, data quality: 3
+    # Reference: HAG2022
+    # Description: valid in conjunction with Zn(OH)2_epsilon(s)
+
+3 H2O + Zn+2 = Zn(OH)3- + 3 H+
+    # Original equation: Zn<2+> + 3OH<->= Zn(OH)3<->
+    # Editor: Moog
+    log_k     -28.6
+    # Evaluation data class: 1, data quality: 3
+    # Reference: HAG2022
+
+4 H2O + Zn+2 = Zn(OH)4-2 + 4 H+
+    # Original equation: Zn<2+> + 4OH<->= Zn(OH)2<2->
+    # Editor: Moog
+    log_k     -41.1
+    # Evaluation data class: 1, data quality: 3
+    # Reference: HAG2022
+
+H2O + Zn+2 = Zn(OH)+ + H+
+    # Original equation: Zn<2+> + OH<->= Zn(OH)<+>
+    # Editor: Moog
+    log_k     -8.3
+    # Evaluation data class: 1, data quality: 3
+    # Reference: HAG2022
+
+CO3-2 + Zn+2 = ZnCO3
+    # Editor: Moog
+    log_k     4.75
+    # Evaluation data class: 1, data quality: 2
+    # Reference: HAG2022
+
+PHASES
+
+# ###### Solid Phases ##########################################################
+(CdCl2)2:5H2O(cr)
+    Cd2Cl4:5H2O = 2 Cd+2 + 4 Cl- + 5 H2O
+    # Original equation: CdCl2(cr)+2.5H2O=CdCl2(cr):2.5H2O
+    # Editor: Moog
+    log_k     -4.05
+    # Evaluation data class: 1, data quality: 2
+    # Reference: HAG2024
+
+(CdSO4)2:(K2SO4)2:3H2O(cr)
+    Cd2K4(SO4)4:3H2O = 2 Cd+2 + 3 H2O + 4 K+ + 4 SO4-2
+    # Editor: Moog
+    log_k     -9.18
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG2024
+
+(CdSO4)3:(K2SO4):5H2O(cr)
+    Cd3K2(SO4)4:5H2O = 3 Cd+2 + 5 H2O + 2 K+ + 4 SO4-2
+    # Editor: Moog
+    log_k     -9.19
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG2024
+
+(CdSO4):(Na2SO4):2H2O(cr)
+    CdNa2(SO4)2:2H2O = Cd+2 + 2 H2O + 2 Na+ + 2 SO4-2
+    # Editor: Moog
+    log_k     -3.39
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG2024
+
+(KCl)3(PbCl2)3:H2O(s)
+    (KCl)3(PbCl2)3:H2O = 9 Cl- + H2O + 3 K+ + 3 Pb+2
+    # Editor: Moog
+    log_k     -15.03
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG1999
+
+(MgCl2)3(PbCl2):19H2O(s)
+    (MgCl2)3(PbCl2):19H2O = 8 Cl- + 19 H2O + 3 Mg+2 + Pb+2
+    # Editor: Moog
+    log_k     6.36
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG1999
+
+(Na2SO4)2(PbCl2)(PbSO4)2:5(H2O)(s)
+    (Na2SO4)2(PbCl2)(PbSO4)2:5(H2O) = 2 Cl- + 5 H2O + 4 Na+ + 3 Pb+2 + 4 SO4-2
+    # Editor: Moog
+    log_k     -15.83
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG1999
+
+(PbO)3(PbSO4):H2O(s)
+    (PbO)3(PbSO4):H2O + 6 H+ = 4 H2O + 4 Pb+2 + SO4-2
+    # Editor: Moog
+    log_k     20.3
+    # Evaluation data class: 1, data quality: 3
+    # Reference: MOO2022
+    # Description: Determined from equilibrium with	(PbO)3(PbSO4):H2O [CHA1956a,CHA1956b,CHA1956c]
+
+(PbO)6(PbCl2):2H2O(s)
+    (PbO)6(PbCl2):2H2O + 12 H+ = 2 Cl- + 8 H2O + 7 Pb+2
+    # Editor: Moog
+    log_k     59.3
+    # Evaluation data class: 1, data quality: 3
+    # Reference: MOO2022
+
+(UO2)(H2PO4)2:3H2O(cr)
+    UO2(H2PO4)2:3H2O = 3 H2O + 4 H+ + 2 PO4-3 + UO2+2
+    # Original equation: UO2(H2PO4)2:3H2O(cr) + 2H+ = UO2<2+> + 2H3PO4<0> + 3H2O(l)
+    # Editor: Richter
+    log_k     -45.1
+    # Evaluation data class: 3, data quality: 3
+    # Reference: GRE/FUG1992
+    # Description: original equation: UO2(H2PO4)2:3H2O(cr) + 2H+ = UO2<2+> + 2H3PO4<0> + 3H2O(l), original value logK=-1.7; not thermodynamic stable at low phosphoric acid concentration, not selected by [GRE/FUG1992] but given as a guideline
+
+(UO2)3(PO4)2:4H2O(cr)
+    (UO2)3(PO4)2:4H2O = 4 H2O + 2 PO4-3 + 3 UO2+2
+    # Original equation: 4H2O(l)+2H3PO4<0> + 3UO2<2+> = 6H+ + (UO2)3(PO4)2:4H2O(cr)
+    # Editor: Richter
+    log_k     -49.364
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: original equation: 4H2O(l)+2H3PO4<0> + 3UO2<2+> = 6H<+> + (UO2)3(PO4)2:4H2O(cr), original value 5.960+-0.300
+
+(UO2)3(PO4)2:6H2O(cr)
+    (UO2)3(PO4)2:6H2O = 6 H2O + 2 PO4-3 + 3 UO2+2
+    # Original equation: (UO2)3(PO4)2:4H2O(cr) + 2H2O(g) = (UO2)3(PO4)2:6H2O(cr)
+    # Editor: Richter
+    log_k     -49.324828807307
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CF
+    -analytical_expression     -5.14936986111631E+1   0      6.46648532019597E+2   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+
+4Zn(OH)2:Zn(SO4):3H2O(s)
+    Zn5(OH)8(SO4):3H2O + 8 H+ = 11 H2O + SO4-2 + 5 Zn+2
+    # Original equation: 4Zn(OH)2:ZnSO4:3H2O = 5Zn2+ + SO42- + 8OH- + 3H2O
+    # Editor: Moog
+    log_k     36.81
+    # Evaluation data class: 1, data quality: 3
+    # Reference: HAG2022
+
+Al(OH)3(am)
+    # Description: As discribed in CEMDATA07
+    Al(OH)3 + H2O = Al(OH)4- + H+
+    # Description: amorphous Al(OH)3 as described in CEMDATA07 original reaction in CEMDATA07 with LOGK298 = 0.24
+    # Original equation: Al(OH)3(am) + OH<-> = Al(OH)4<->
+    # Editor: Miron
+    log_k     -13.758637804182
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -analytical_expression              2.176778E+1   0           -4.66880238E+3     -8.02897606416466E+0   0   0 
+    # Evaluation data class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 373.15 K.
+    # Reference: LOT/MAT2008
+
+Alunogen
+    # Synonyms: Alunogenite, Davite, Katharite, Katherite, Keramostypterite, Saldanite, Solfatarite, Stypterite
+    Al2(SO4)3:17H2O = 2 Al(OH)4- + 9 H2O + 8 H+ + 3 SO4-2
+    # Description: Data only for 298.15
+    # Editor: Miron
+    log_k     -52.9041
+    # Evaluation data class: 1, data quality: 1
+    # Reference: MIR2023
+
+Am(CO3)(OH):0.5H2O(cr)
+    Am(CO3)(OH):0.5H2O + H+ = Am+3 + CO3-2 + 1.5 H2O
+    # Original equation: Am<3+> + CO3<2> + OH<-> + 0.5H2O(l) = AmCO3OH:0.5H2O(c). log K=22.4 (GUI/FAN2003)
+    # Editor: Marquardt
+    log_k     -8.399
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: original equation: Am<3+> + CO3<2> + OH<-> + 0.5H2O(l) = AmCO3OH:0.5H2O(c). log K=22.4 (GUI/FAN2003)
+
+Am(CO3)(OH)_hyd(am)
+    Am(CO3)(OH) + H+ = Am+3 + CO3-2 + H2O
+    # Original equation: Am<3+> + CO3<2> + OH<-> = AmCO3OH(am.hyd). log K=20.2 +- 1.0 (GUI/FAN2003)
+    # Editor: Marquardt
+    log_k     -6.199
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: original equation: Am<3+> + CO3<2> + OH<-> = AmCO3OH(am.hyd). log K=20.2 +- 1.0 (GUI/FAN2003)
+
+Am(OH)3(am)
+    Am(OH)3 + 3 H+ = Am+3 + 3 H2O
+    # Editor: Marquardt
+    log_k     16.9
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+Andersonite
+    CaNa2(UO2(CO3)3):6H2O = 3 CO3-2 + Ca+2 + 6 H2O + 2 Na+ + UO2+2
+    # Original equation: Na2CaUO2(CO3)3:6H2O = 2 Na<+> + Ca<2+> + UO2<2+> + 3CO3<2-> + 6H2O
+    # Editor: Bok
+    log_k     -37.5
+    # Evaluation data class: 1, data quality: 2
+    # Reference: GOR/BUR2008
+    # Additional reference: ALW/WIL1980
+    # Description: Ksp calculated from reported standard state Gibbs free energy of formation from ALW/WIL1980 by GOR/BUR2008.
+
+Anglesite
+    # Synonyms: Lead sulphate, Lead Vitriol
+    PbSO4 = Pb+2 + SO4-2
+    # Original equation: PbSO4(s) = Pb2+ + SO4 2
+    # Editor: Moog
+    log_k     -7.84
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG1999
+    -analytical_expression     -5.82178538973031E+0   0     -6.01727874706442E+2   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+
+Anhydrite
+    # Synonyms: Karstenite, Muriacite
+    Ca(SO4) = Ca+2 + SO4-2
+    # Editor: Freyer
+    log_k     -4.419928372977
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      4.18620456120321E+3      2.47533819574229E+0     -8.53777536159083E+4     -1.82921595448915E+3   0      -1.3050746205522E-3 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 293.15 K - 383.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 45.993446 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: HAR1989
+
+Antarcticite
+    # Synonyms: Antarkticite
+    CaCl2:6H2O = Ca+2 + 2 Cl- + 6 H2O
+    # Editor: Freyer
+    log_k     4.2335144109734
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      2.15658150420354E+4      6.34726519686675E+0     -8.52743808602194E+5     -8.42297892664862E+3      3.52003399901873E+7     -1.66236404987772E-3 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 300.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 127.740921 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: AGR/BUS1986
+
+Aragonite
+    # Synonyms: Arragonite, Arragon Spar, Chimborazite, Conchite, Iglite, Igloite, Ktypéite, Oserskite, Pisa Carolina, Stillatitius lapis, Winnieite
+    Ca(CO3) = CO3-2 + Ca+2
+    # Editor: Freyer
+    log_k     -8.3121263264047
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      1.39910778807095E+2   0     -6.13502003457388E+3     -5.15859041433641E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 34.159352 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: ANT/HAS2010
+
+Arcanite
+    # Synonyms: Arkanite
+    K2(SO4) = 2 K+ + SO4-2
+    # Editor: Freyer
+    log_k     -1.7762409268812
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      3.61309603790363E+1     -7.85366282006047E-2     -5.63690085837735E+3   0   0      4.96634087346348E-5 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 423.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 65.265618 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: MCG1972
+
+Artinite
+    Mg2(CO3)(OH)2:3H2O + 2 H+ = CO3-2 + 5 H2O + 2 Mg+2
+    # Editor: Freyer
+    log_k     9.8153518977789
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression       7.2509863110623E+1   0      2.43587258246064E+3     -2.86386433339347E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 96.886414 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: AKA/IWA1977
+
+Autunite
+    Ca((UO2)2(PO4)2):6H2O = Ca+2 + 6 H2O + 2 PO4-3 + 2 UO2+2
+    # Editor: Richter
+    log_k     -50.0
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GRE/GAO2020
+
+Bayelite
+    Mg2(UO2(CO3)3):18H2O = 3 CO3-2 + 18 H2O + 2 Mg+2 + UO2+2
+    # Original equation: Mg2UO2(CO3)3:18H2O = 2Mg<2+> + UO2<2+> + 3CO3<2-> + 18H2O
+    # Editor: Bok
+    log_k     -36.6
+    # Evaluation data class: 1, data quality: 2
+    # Reference: GOR/BUR2008
+    # Additional reference: ALW/WIL1980
+    # Description: Ksp calculated from reported standard state Gibbs free energy of formation from ALW/WIL1980 by GOR/BUR2008.
+
+Becquerelite
+    # Synonyms: Beckerelite
+    Ca(UO2)6O4(OH)6:8H2O + 14 H+ = Ca+2 + 18 H2O + 6 UO2+2
+    # Editor: Richter
+    log_k     40.5
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+Bianchite
+    Zn(SO4):6H2O = 6 H2O + SO4-2 + Zn+2
+    # Editor: Moog
+    log_k     -1.859
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG2022
+    # Description: metastable at 25C
+
+Bischofite
+    MgCl2:6H2O = 2 Cl- + 6 H2O + Mg+2
+    # Editor: Freyer
+    log_k     4.4553681214085
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression     -1.02068700425842E+4     -5.73024998270583E+0      2.13942484267115E+5      4.42587376871729E+3   0      2.82019410181542E-3 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 389.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 127.223204 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: AGR/BUS1985
+
+Blixite
+    (PbO)3(PbCl2):H2O + 6 H+ = 2 Cl- + 4 H2O + 4 Pb+2
+    # Editor: Moog
+    log_k     22.2
+    # Evaluation data class: 1, data quality: 3
+    # Reference: MOO2022
+
+Bloedite
+    # Synonyms: Astrachanite, Astrakanite, Astrakhanite
+    MgNa2(SO4)2:4H2O = 4 H2O + Mg+2 + 2 Na+ + 2 SO4-2
+    # Editor: Freyer
+    log_k     -2.3468963507513
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      4.65228443995458E+1     -8.18243523420599E-2     -7.29686732274402E+3   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 150.662549 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: VIZ/GAR1999
+
+Boehmite
+    AlO(OH) + 2 H2O = Al(OH)4- + H+
+    # Editor: Miron
+    log_k     -14.243856974327
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression                7.1036E+0   0              -3.00413E+3     -4.55520408947012E+0   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 473.15 K.
+    # Reference: MIR2023
+    # Additional reference: BEN/PAL2001
+
+Boltwoodite
+    K(UO2(SiO3OH)):H2O + 3 H+ = H2O + K+ + Si(OH)4 + UO2+2
+    # Editor: Richter
+    log_k     4.48
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GRE/GAO2020
+
+Brucite
+    # Synonyms: Nemalite, Texalite
+    Mg(OH)2 + 2 H+ = 2 H2O + Mg+2
+    # Editor: Freyer
+    log_k     17.119670311764
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression     -5.19075463702429E+0   0      6.65185933743079E+3   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 24.711729 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: DES/CAL1996
+
+Burkeite
+    # Synonyms: Gauslinite
+    Na6(CO3)(SO4)2 = CO3-2 + 6 Na+ + 2 SO4-2
+    # Editor: Freyer
+    log_k     -0.76588265228594
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+
+C2AH7.5
+    Ca2Al2(OH)10:2.5H2O + 2 H+ = 2 Al(OH)4- + 2 Ca+2 + 4.5 H2O
+    # Description: Original reaction from LOT/KUL2019, Table B2, C2AH7.5
+    # Original equation: Ca2Al2(OH)10:2.5H2O(cr) = 2Ca<2+> + 2Al(OH)4<> + 2OH<> + 2.5H2O(l)
+    # Editor: Miron
+    log_k     14.205
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: LOT/PEL2012
+    # Description: exact value was used instead of rounded value given in the reference.
+    -analytical_expression      1.78085320407881E+1   0       3.8272712229376E+3     -6.64404757466165E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 180 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: LOT/PEL2012
+
+C4AH11
+    Ca4Al2(OH)14:4H2O + 6 H+ = 2 Al(OH)4- + 4 Ca+2 + 10 H2O
+    # Description: Original reaction from LOT/KUL2019, Table B2, C4AH11. Thermodynamic data from hydration-dehydration experiments.
+    # Original equation: Ca4Al2(OH)14:4H2O(cr) + 6H<+> = 2AlO2<-> + 4Ca<2+> + 14H2O(l)
+    # Editor: Miron
+    log_k     60.494
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: BAQ/MAT2015
+    # Description: Thermodynamic data from hydration-dehydration experiments. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      7.57883357789727E+1   0      1.57235779117618E+4     -2.74937428663866E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 257.3 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: BAQ/MAT2015
+
+C4AH13
+    # Description: Metastable compared with Hydrogarnet.
+    Ca4Al2(OH)14:6H2O + 6 H+ = 2 Al(OH)4- + 4 Ca+2 + 12 H2O
+    # Description: Original reaction from LOT/KUL2019, Table B2, C4AH13. Thermodynamic data from hydration-dehydration experiments.
+    # Original equation: Ca4Al2(OH)14:6H2O(s) + 6H+ = 2AlO2<-> + 4Ca<2+>  + 16H2O(l)
+    # Editor: Miron
+    log_k     58.76
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: BAQ/MAT2015
+    # Description: Thermodynamic data from hydration-dehydration experiments. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      5.53248343067598E+1   0       1.5044874910155E+4     -1.90046076076642E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+    -Vm 274.5 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: BAQ/MAT2015
+
+C4AH19
+    Ca4Al2(OH)14:12H2O + 6 H+ = 2 Al(OH)4- + 4 Ca+2 + 18 H2O
+    # Description: Original reaction from LOT/KUL2019, Table B2, C4AH19
+    # Original equation: Ca4Al2(OH)14:12H2O(cr) + 6H<+> = 2AlO2<-> + 4Ca<2+> + 22H2O(l)
+    # Editor: Miron
+    log_k     58.561
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: LOT/PEL2012
+    # Description: Additional reference: BAQ/MAT2015. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression     -1.19007892012336E+1   0      1.62417438182261E+4      6.46075355011901E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 368.7 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: LOT/PEL2012
+
+Ca(SeO4):2H2O(cr)
+    # Synonyms: Calcium selenate dihydrate, Se-Gypsum
+    Ca(SeO4):2H2O = Ca+2 + 2 H2O + SeO4-2
+    # Editor: Bok
+    log_k     -2.601
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -analytical_expression                7.9791E-1                 -1.14E-2   0   0   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 333.15 K.
+    # Reference: BIS/HAG2016
+    # Description: Original solubility product data: LogK(T) = -2.601-0.0114(T-298.15K)
+
+Ca(SO4):0.5H2O(cr)
+    # Synonyms: Hemihydrate, Bassanite, Miltonite, Mirupolskite, Polyhydrate, Vibertite
+    Ca(SO4):0.5H2O = Ca+2 + 0.5 H2O + SO4-2
+    # Editor: Freyer
+    log_k     -3.8865548673535
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      1.02743890736348E+4      5.96871614927567E+0     -2.10500542674858E+5     -4.47772991761381E+3   0     -3.05956584171984E-3 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 52.400087 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: SCH/PAS2011
+
+Ca0.5NpO2(OH)2:1.3H2O(s)
+    Ca0.5NpO2(OH)2:1.3H2O + 2 H+ = 0.5 Ca+2 + 3.3 H2O + NpO2+
+    # Editor: Gaona
+    log_k     12.26
+    # Evaluation data class: 1, data quality: 1
+    # Reference: FEL/ALT2016
+
+Ca2Cl2(OH)2(cr)
+    # Description: phase composition changed to CaCl2(OH)2(cr) 2019-10-01
+    Ca2Cl2(OH)2 + 2 H+ = 2 Ca+2 + 2 Cl- + 2 H2O
+    # Description: phase composition changed to Ca2Cl2(OH)2(cr) 2019-10-01
+    # Editor: Freyer
+    log_k     27.107582959566
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression               1.62455E+3               1.96624E+0   0     -8.31023683327388E+2   0              -1.43276E-3 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 393.15 K.
+    # Reference: SOH2020
+    -Vm 77.115283 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: WES/WER1981
+
+Ca4Cl2(OH)6:12H2O(cr)
+    Ca4Cl2(OH)6:12H2O + 6 H+ = 4 Ca+2 + 2 Cl- + 18 H2O
+    # Editor: Freyer
+    log_k     69.2763689303
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression               2.47886E+2               -1.0509E+0   0   0   0               1.51548E-3 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 313.15 K.
+    # Reference: SOH2020
+    -Vm 301.89307692308 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: HAU/SCH2019
+
+CAH10
+    # Description: Metastable compared with Hydrogarnet.
+    CaAl2(OH)8:6H2O = 2 Al(OH)4- + Ca+2 + 6 H2O
+    # Description: Original reaction from LOT/KUL2019, Table B2, CAH10
+    # Original equation: CaOAl2O3:10H2O(s) = 2AlO2<-> + Ca<2+> + 10H2O(l)
+    # Editor: Miron
+    log_k     -7.594
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: LOT/PEL2012
+    # Description: Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      1.36549235552625E+1   0      -2.5054783090069E+3      -5.1912860769907E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+    -Vm 193 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: LOT/PEL2012
+
+Calcite
+    # Synonyms: Androdamas, Calc Spar, Focobonite
+    Ca(CO3) = CO3-2 + Ca+2
+    # Editor: Freyer
+    log_k     -8.4731478603063
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      1.40257086151496E+2   0     -6.14927974875508E+3     -5.17716038246436E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 36.932435 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: MAS/STR1995
+
+CaNa2(SeO4)2:6H2O(cr)
+    # Synonyms: sodium calcium selenate
+    # Description: sodium calcium selenate double salt
+    CaNa2(SeO4)2:6H2O = Ca+2 + 6 H2O + 2 Na+ + 2 SeO4-2
+    # Editor: Bok
+    log_k     -2.9942
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression               -2.9942E+0   0   0   0   0   0 
+    # Evaluation data class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: BOK2021
+
+CaNpO2(OH)2.6Cl0.4:2H2O(s)
+    CaNpO2(OH)2.6Cl0.4:2H2O + 2.6 H+ = Ca+2 + 0.4 Cl- + 4.6 H2O + NpO2+
+    # Editor: Gaona
+    log_k     19.89
+    # Evaluation data class: 1, data quality: 1
+    # Reference: FEL/ALT2016
+
+Carnallite
+    KMgCl3:6H2O = 3 Cl- + 6 H2O + K+ + Mg+2
+    # Editor: Freyer
+    log_k     4.3302929365012
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression     -1.05817430314465E+2     -4.80914119095867E-2      1.64562709845159E+3      4.80783417403332E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 173.441935 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: SCH/SEN1985
+
+CaU2O7:3H2O(cr)
+    CaU2O7:3H2O + 6 H+ = Ca+2 + 6 H2O + 2 UO2+2
+    # Editor: Richter
+    log_k     23.4
+    # Evaluation data class: 1, data quality: 2
+    # Reference: ALT/NEC2005a
+
+Cd(OH)2_beta(s)
+    Cd(OH)2 + 2 H+ = Cd+2 + 2 H2O
+    # Original equation: Cd<2+>+2(OH)=Cd(OH)2_beta
+    # Editor: Moog
+    log_k     13.61
+    # Evaluation data class: -1, data quality: 1
+    # Reference: HAG2024
+    # Description: Original LOGK298 for dissolution reaction = -14.39
+
+Cd(SO4):(Cd(OH)2)2(cr)
+    Cd3(OH)4(SO4) + 4 H+ = 3 Cd+2 + 4 H2O + SO4-2
+    # Original equation: 3Cd<2+>+SO4<2->+4OH<->=CdSO4:2Cd(OH)2
+    # Editor: Moog
+    log_k     22.5
+    # Evaluation data class: 1, data quality: 3
+    # Reference: WAG/EVA1982
+    # Description: Original LOGK298 for dissolution reaction = -33.5
+
+CdCl2:(CaCl2)2:12H2O(cr)
+    Ca2CdCl6:12H2O = 2 Ca+2 + Cd+2 + 6 Cl- + 12 H2O
+    # Editor: Moog
+    log_k     5.0
+    # Evaluation data class: 1, data quality: 2
+    # Reference: HAG2024
+
+CdCl2:(Cd(OH)2)3(cr)
+    Cd4Cl2(OH)6 + 6 H+ = 4 Cd+2 + 2 Cl- + 6 H2O
+    # Original equation: 4Cd<2+>+2Cl<->+6OH<->=CdCl2:3Cd(OH)2
+    # Editor: Moog
+    log_k     33.45
+    # Evaluation data class: -1, data quality: 1
+    # Reference: FEI/REI1951
+    # Description: Original LOGK298 for dissolution reaction = -50.55
+
+CdCl2:(KCl)4(cr)
+    CdK4Cl6 = Cd+2 + 6 Cl- + 4 K+
+    # Editor: Moog
+    log_k     -0.96
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG2024
+
+CdCl2:(MgCl2)2:12H2O(cr)
+    CdMg2Cl6:12H2O = Cd+2 + 6 Cl- + 12 H2O + 2 Mg+2
+    # Editor: Moog
+    log_k     5.4
+    # Evaluation data class: 1, data quality: 2
+    # Reference: HAG2024
+
+CdCl2:(NaCl)2:3H2O(cr)
+    CdNa2Cl4:3H2O = Cd+2 + 4 Cl- + 3 H2O + 2 Na+
+    # Editor: Moog
+    log_k     -0.64
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG2024
+
+CdCl2:Cd(OH)2(cr)
+    Cd2Cl2(OH)2 + 2 H+ = 2 Cd+2 + 2 Cl- + 2 H2O
+    # Original equation: 2Cd<2+>+2Cl<->+2OH<->=CdCl2:Cd(OH)2
+    # Editor: Moog
+    log_k     7.0
+    # Evaluation data class: -1, data quality: 2
+    # Reference: FEI/REI1951
+    # Description: Original LOGK298 for dissolution reaction = -21
+
+CdCl2:KCl:H2O(cr)
+    CdKCl3:H2O = Cd+2 + 3 Cl- + H2O + K+
+    # Editor: Moog
+    log_k     -3.04
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG2024
+
+Cejkaite
+    Na4(UO2(CO3)3) = 3 CO3-2 + 4 Na+ + UO2+2
+    # Original equation: 4 Na<+> + UO2(CO3)3<4-> = Na4UO2(CO3)3(cr)
+    # Editor: Richter
+    log_k     -27.18
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Additional reference: GRE/FUG1992
+    # Description: original equation: 4Na<+> UO2(CO3)3<4-> = Na4(UO2)(CO3)3(cr); original value 5.34 +-0.160
+
+Celestite
+    # Synonyms: Celestine
+    Sr(SO4) = SO4-2 + Sr+2
+    # Editor: Moog
+    log_k     -6.55
+    # Evaluation data class: 1, data quality: 3
+    # Reference: DYR/IVA1969
+
+Cerussite
+    # Synonyms: White Lead Ore, Cerussit
+    # Description: May form solid solutions with Aragonite (Tarnowitzite), due to different crystal structure apparently not with Calcite and Magnesite. At 60C PbMg(CO3)2 is formed (Bttcher 1993) which ist not present in THEREDA.
+    PbCO3 = CO3-2 + Pb+2
+    # Description: Applicability for calculations for high-saline solutions to be determined
+    # Original equation: PbCO3(s) = Pb2+ + CO32
+    # Editor: Moog
+    log_k     -13.59
+    # Evaluation data class: 1, data quality: 1
+    # Reference: MOO2022
+    -analytical_expression      -8.1980199596507E+0   0     -1.60761884903016E+3   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+
+Challacolloite 
+    (KCl)(PbCl2)2 = 5 Cl- + K+ + 2 Pb+2
+    # Editor: Moog
+    log_k     -10.51
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG1999
+
+Changoite
+    Na2Zn(SO4)2:4H2O = 4 H2O + 2 Na+ + 2 SO4-2 + Zn+2
+    # Editor: Moog
+    log_k     -3.41
+    # Evaluation data class: 1, data quality: 3
+    # Reference: HAG2022
+
+Chernikovite
+    # Synonyms: Hydrogen Autunite
+    UO2(HPO4):4H2O = 4 H2O + H+ + PO4-3 + UO2+2
+    # Original equation: 4H2O(l)+H3PO4<0> + UO2<2+> = 2H+ + UO2(HPO4):4H2O(cr)
+    # Editor: Richter
+    log_k     -24.202
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Additional reference: GRE/FUG1992
+    # Description: original equation: 4H2O(l)+H3PO4<0> + UO2<2+> = 2H+ + UO2(HPO4):4H2O(cr), original value 2.500+-0.090
+
+Chloraluminite
+    # Synonyms: Chloralluminite
+    AlCl3:6H2O = Al(OH)4- + 3 Cl- + 2 H2O + 4 H+
+    # Editor: Miron
+    log_k     -15.85681761842
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression              1.177793E+2   0             -1.328334E+4     -3.60015856786389E+1   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 373.15 K.
+    # Reference: MIR2023
+
+Chloropyromorphite
+    Pb5(PO4)3Cl = Cl- + 3 PO4-3 + 5 Pb+2
+    # Editor: Moog
+    log_k     -85.3
+    # Evaluation data class: 1, data quality: 3
+    # Reference: MOO2022
+
+Clarkeite
+    # Synonyms: Brown Gummite
+    Na2U2O7:H2O + 6 H+ = 4 H2O + 2 Na+ + 2 UO2+2
+    # Description: alternative formula NaUO2OOH(cr)
+    # Original equation: Na<+> + UO2<2+> + 2H2O(l) = 0.5Na2U2O7:H2O(cr) + 3H<+>
+    # Editor: Richter
+    log_k     24.4
+    # Evaluation data class: 1, data quality: 1
+    # Reference: ALT/YAL2017
+    # Description: original formation reaction in [ALT/YAL2017]: Na<+> + UO2<2+> + 2 H2O(l) = 0.5 Na2U2O7:H2O(cr) + 3H<+> with logK=-12.2+-0.2; alternative formula NaUO2OOH(cr); same logK in [NEC/FAN2001] and [ALTBRE2004] (but other formation reactions)
+
+Cm(CO3)(OH):0.5H2O(cr)
+    Cm(CO3)(OH):0.5H2O + H+ = CO3-2 + Cm+3 + 1.5 H2O
+    # Editor: Marquardt
+    log_k     -8.399
+    # Evaluation data class: 2, data quality: 2
+    # Reference: GUI/FAN2003
+
+Cm(CO3)(OH)_hyd(am)
+    Cm(CO3)(OH) + H+ = CO3-2 + Cm+3 + H2O
+    # Editor: Marquardt
+    log_k     -6.199
+    # Evaluation data class: 2, data quality: 2
+    # Reference: GUI/FAN2003
+
+Cm(OH)3(am)
+    Cm(OH)3 + 3 H+ = Cm+3 + 3 H2O
+    # Editor: Marquardt
+    log_k     16.9
+    # Evaluation data class: 2, data quality: 1
+    # Reference: NEC/ALT2009
+    # Additional reference: RAB/ALT2008
+
+CNASH_5CA
+    # Synonyms: CNASH_5CA_ss
+    (CaO)1.25(SiO2)1(Al2O3)0.125:1.625H2O + 2.25 H+ = 0.25 Al(OH)4- + 1.25 Ca+2 + 0.25 H2O + Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, 5CA
+    # Original equation: (CaO)1.25(SiO2)1(Al2O3)0.125:1.625H2O(gel) + 2.25H<+> = 0.25AlO2<-> + 1.25Ca<2+> + 2.75H2O(l) + SiO2(aq)
+    # Editor: Miron
+    log_k     15.891
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: MYE/BER2014
+    # Description: Exact value was used instead of rounded value given in the reference.
+    -analytical_expression     -8.68158314847026E+0   0       5.2257038004785E+3      2.84731150723253E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 57.3 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: MYE/BER2014
+
+CNASH_5CNA
+    # Synonyms: CNASH_5CNA_ss
+    (CaO)1.25(SiO2)1(Al2O3)0.125(Na2O)0.25:1.375H2O + 2.75 H+ = 0.25 Al(OH)4- + 1.25 Ca+2 + 0.25 H2O + 0.5 Na+ + Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, 5CNA
+    # Original equation: (CaO)1.25(SiO2)1(Al2O3)0.125(Na2O)0.25:1.375H2O(gel) + 2.75H<+> = 0.25AlO2<-> + 1.25Ca<2+> + 0.5Na<+> + 2.75H2O(l) + SiO2(aq)
+    # Editor: Miron
+    log_k     23.241
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: MYE/BER2014
+    # Description: Exact value was used instead of rounded value given in the reference.
+    -analytical_expression     -1.57990582406249E+1   0      7.76989026862047E+3      5.24552860000168E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 64.5 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: MYE/BER2014
+
+CNASH_INFCA
+    # Synonyms: CNASH_INFCA_ss
+    (CaO)1(SiO2)1.1875(Al2O3)0.15625:1.65625H2O + 0.5 H2O + 1.6875 H+ = 0.3125 Al(OH)4- + Ca+2 + 1.1875 Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, INFCA
+    # Original equation: (CaO)1(SiO2)1.1875(Al2O3)0.15625:1.65625H2O(gel) + 1.6875H<+> = 0.3125AlO2<-> + Ca<2+> + 2.5H2O(l) + 1.1875SiO2(aq)
+    # Editor: Miron
+    log_k     8.955
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: MYE/BER2014
+    # Description: Exact value was used instead of rounded value given in the reference.
+    -analytical_expression     -4.74325212190043E+0   0      2.83507104903479E+3      1.69306429362644E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 59.3 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: MYE/BER2014
+
+CNASH_INFCN
+    # Synonyms: CNASH_INFCN_ss
+    (CaO)1(SiO2)1.5(Na2O)0.3125:1.1875H2O + 0.5 H2O + 2.625 H+ = Ca+2 + 0.625 Na+ + 1.5 Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, INFCN
+    # Original equation: (CaO)1(SiO2)1.5(Na2O)0.3125:1.1875H2O(gel) + 2.625H<+> = Ca<2+> + 0.625Na<+> + 2.5H2O(l) + 1.5SiO2(aq)
+    # Editor: Miron
+    log_k     18.761
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: MYE/BER2014
+    # Description: Exact value was used instead of rounded value given in the reference.
+    -analytical_expression     -2.08455889220458E+1   0      6.10748736380258E+3      7.72781558985436E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 71.1 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: MYE/BER2014
+
+CNASH_INFCNA
+    # Synonyms: CNASH_INFCNA_ss
+    (CaO)1(SiO2)1.1875(Al2O3)0.15625(Na2O)0.34375(H2O)1.3125 + 0.5 H2O + 2.375 H+ = 0.3125 Al(OH)4- + Ca+2 + 0.6875 Na+ + 1.1875 Si(OH)4
+    # Description: Original reaction from Phreeqc version of CEMDATA18. Reaction in LOT/KUL2019, Table B2, INFCNA is incorrect!
+    # Original equation: (CaO)1(SiO2)1.1875(Al2O3)0.15625(Na2O)0.34375(H2O)1.3125(s) + 2.375 H<+> = 0.3125 AlO2<-> + 1.1875 SiO2<0> + 0.6875 Na<+> + 2.5 H2O(l) + Ca<2+>
+    # Editor: Miron
+    log_k     17.479
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: MYE/BER2014
+    -analytical_expression     -1.45281263040541E+1   0      5.86147946498874E+3      4.99007157367061E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+    -Vm 69.3 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: MYE/BER2014
+
+CNASH_T2C
+    # Synonyms: CNASH_T2C_ss
+    (CaO)1.5(SiO2)1:2.5H2O + 3 H+ = 1.5 Ca+2 + 2 H2O + Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, T2C-CNASHss
+    # Original equation: (CaO)1.5(SiO2)1:2.5H2O(gel) + 3H<+> = 1.5Ca<2+> + 4H2O(l) + SiO2(aq)
+    # Editor: Miron
+    log_k     25.567
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: MYE/BER2014
+    # Description: Exact value was used instead of rounded value given in the reference.
+    -analytical_expression     -1.82533595497116E+1   0      7.51723854974502E+3      7.51986587303401E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 80.6 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: MYE/BER2014
+
+CNASH_T5C
+    # Synonyms: CNASH_T5C_ss
+    (CaO)1.25(SiO2)1.25:2.5H2O + 2.5 H+ = 1.25 Ca+2 + 1.25 H2O + 1.25 Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, T5C-CNASHss
+    # Original equation: (CaO)1.25(SiO2)1.25:2.5H2O(gel) + 2.5H<+> = 1.25Ca<2+> + 3.75H2O(l) + 1.25SiO2(aq)
+    # Editor: Miron
+    log_k     18.447
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: MYE/BER2014
+    # Description: Exact value was used instead of rounded value given in the reference.
+    -analytical_expression       -1.853528004133E+1   0      5.22052484305188E+3      7.86949561669899E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 79.3 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: MYE/BER2014
+
+CNASH_TobH
+    # Synonyms: CNASH_TobH_ss
+    (CaO)1(SiO2)1.5:2.5H2O + 2 H+ = Ca+2 + 0.5 H2O + 1.5 Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, TobH-CNASHss
+    # Original equation: (CaO)1(SiO2)1.5:2.5H2O(gel) + 2H<+> = Ca<2+> + 3.5H2O(l) + 1.5SiO2(aq)
+    # Editor: Miron
+    log_k     12.799
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: MYE/BER2014
+    # Description: Exact value was used instead of rounded value given in the reference.
+    -analytical_expression     -1.88162834482554E+1   0       3.3625032383113E+3      8.21900508869434E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 85 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: MYE/BER2014
+
+CO3-Hydrotalcite
+    Mg3Al(OH)8(CO3)0.5:2.5H2O + 4 H+ = Al(OH)4- + 0.5 CO3-2 + 6.5 H2O + 3 Mg+2
+    # Description: Original reaction from LOT/KUL2019, Table B2, Mg3AlC0.5OH
+    # Original equation: Mg3Al(OH)8(CO3)0.5:2.5H2O(s) + 4H<+> = AlO2<-> + 0.5CO3<2-> + 3Mg<2+> + 8.5H2O(l)
+    # Editor: Miron
+    log_k     22.719
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: ROZ/BER2011
+    # Description: Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      3.07674818182982E+1   0      9.20010844210954E+3     -1.57231153730045E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+    -Vm 115 cm3/mol
+    # Reference: LOT/KUL2019
+
+Coffinite
+    U(SiO4) + 4 H+ = Si(OH)4 + U+4
+    # Editor: Richter
+    log_k     -5.25
+    # Evaluation data class: 1, data quality: 1
+    # Reference: SZE/MES2016
+
+Cotunnite
+    PbCl2 = 2 Cl- + Pb+2
+    # Editor: Moog
+    log_k     -4.77
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG1999
+    -analytical_expression     -1.85234750367255E-1   0     -1.36694604870378E+3   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+
+Cs2(SO4)(cr)
+    Cs2(SO4) = 2 Cs+ + SO4-2
+    # Editor: Moog
+    log_k     0.66
+    # Evaluation data class: 1, data quality: 3
+    # Reference: SCH/MUN2012
+
+Cs2CaCl4:2H2O(s)
+    Cs2CaCl4:2H2O = Ca+2 + 4 Cl- + 2 Cs+ + 2 H2O
+    # Editor: Moog
+    log_k     6.31
+    # Evaluation data class: 1, data quality: 3
+    # Reference: SCH/MUN2013
+
+Cs2Mg(SO4)2:6H2O(cr)
+    Cs2Mg(SO4)2:6H2O = 2 Cs+ + 6 H2O + Mg+2 + 2 SO4-2
+    # Editor: Moog
+    log_k     -4.26
+    # Evaluation data class: 1, data quality: 3
+    # Reference: SCH/MUN2013
+
+Cs5CaCl7(s)
+    Cs5CaCl7 = Ca+2 + 7 Cl- + 5 Cs+
+    # Editor: Moog
+    log_k     10.08
+    # Evaluation data class: 1, data quality: 3
+    # Reference: SCH/MUN2013
+
+CsCl(cr)
+    CsCl = Cl- + Cs+
+    # Editor: Moog
+    log_k     1.53
+    # Evaluation data class: 1, data quality: 1
+    # Reference: SCH/MUN2012
+
+CSH-II_Jen
+    SiO2(CaO)1.666667:2.1H2O + 3.333334 H+ = 1.666667 Ca+2 + 1.766667 H2O + Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, Jennite
+    # Original equation: SiO2(CaO)1.666667:2.1H2O(gel) + 3.333334H<+> = 1.666667Ca<2+> + 3.766667H2O(l) + SiO2(aq)
+    # Editor: Miron
+    log_k     29.318
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: LOT/MAT2008
+    -analytical_expression      -1.9395849536127E+1   0       8.6695791040946E+3      7.93552476333542E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 78 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: LOT/MAT2008
+
+CSH-II_Tob
+    SiO2(CaO)0.833333:1.333333H2O + 1.666666 H+ = 0.833333 Ca+2 + 0.166666 H2O + Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, Tob-II
+    # Original equation: SiO2(CaO)0.833333:1.333333H2O(gel) + 1.666666H<+> = 0.833333Ca<2+> + 2.166666H2O(l) + SiO2(aq)
+    # Editor: Miron
+    log_k     11.145
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: LOT/MAT2008
+    # Description: Exact value was used instead of rounded value given in the reference.
+    -analytical_expression     -1.39190496704219E+1   0      3.07126863670136E+3       5.9661964445289E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 59 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: LOT/MAT2008
+
+CSH3T_T2C
+    (CaO)1.5SiO2:2.5H2O + 3 H+ = 1.5 Ca+2 + 2 H2O + Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, CSH3T-T2C
+    # Original equation: ((CaO)0.75(SiO2)0.5:1.25H2O)2(gel) + 3H<+> = 1.5Ca<2+> + 4H2O(l) + SiO2(aq)
+    # Editor: Miron
+    log_k     25.273
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: KUL2011
+    # Description: Exact value was used instead of rounded value given in the reference.
+    -analytical_expression     -1.82423621863802E+1   0      7.42807820094359E+3      7.51746043964107E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 81 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: KUL2011
+
+CSH3T_T5C
+    (CaO)1.25(SiO2)1.25:2.5H2O + 2.5 H+ = 1.25 Ca+2 + 1.25 H2O + 1.25 Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, CSH3T-T5C
+    # Original equation: ((CaO)1(SiO2)1:2H2O)1.25(gel) + 2.5H<+> = 1.25Ca<2+> + 3.75H2O(l) + 1.25SiO2(aq)
+    # Editor: Miron
+    log_k     18.139
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: KUL2011
+    # Description: Exact value was used instead of rounded value given in the reference.
+    -analytical_expression     -1.85191998957647E+1   0      5.12780450081838E+3      7.86420366323452E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 79 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: KUL2011
+
+CSH3T_TobH
+    (CaO)1(SiO2)1.5:2.5H2O + 2 H+ = Ca+2 + 0.5 H2O + 1.5 Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, CSH3T-TobH
+    # Original equation: (CaO)1(SiO2)1.5:2.5H2O(gel) + 2H<+> = Ca<2+> + 3.5H2O(l) + 1.5SiO2(aq)
+    # Editor: Miron
+    log_k     12.53
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: KUL2011
+    # Description: Exact value was used instead of rounded value given in the reference.
+    -analytical_expression     -1.88216116363669E+1   0       3.2824697955361E+3      8.22092943540869E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 85 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: KUL2011
+
+CSHQ_JenD
+    # Synonyms: CSHQ_JenD_ss
+    # Description: 
+    (CaO)1.5(SiO2)0.6667:2.5H2O + 3 H+ = 1.5 Ca+2 + 2.6666 H2O + 0.6667 Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, CSHQ-JenD
+    # Original equation: (CaO)1.5(SiO2)0.6667:2.5H2O(gel) + 3H<+> = 1.5Ca<2+> + 4H2O(l) + 0.6667SiO2(aq)
+    # Editor: Miron
+    log_k     28.732
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: KUL2011
+    # Description: Exact value was used instead of rounded value given in the reference.
+    -analytical_expression     -1.55916928543446E+1   0      8.60971671053099E+3      6.24246046970898E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 81 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: KUL2011
+
+CSHQ_JenH
+    # Synonyms: CSHQ_JenH_ss
+    (CaO)1.3333(SiO2):2.1667H2O + 2.6666 H+ = 1.3333 Ca+2 + 1.5 H2O + Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, CSHQ-JenH
+    # Original equation: (CaO)1.3333(SiO2):2.1667H2O(gel) + 2.6666H<+> = 1.3333Ca<2+> + 3.5H2O(l) + SiO2(aq)
+    # Editor: Miron
+    log_k     22.181
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: KUL2011
+    # Description: Exact value was used instead of rounded value given in the reference.
+    -analytical_expression       -1.710920021899E+1   0      6.47056310777688E+3      7.10781513282202E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 76 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: KUL2011
+
+CSHQ_KSiOH
+    # Synonyms: CSHQ_KSiOH_ss
+    (KOH)0.5(SiO2)0.2:0.2H2O + 0.5 H+ = 0.3 H2O + 0.5 K+ + 0.2 Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, KSiOH
+    # Original equation: ((KOH)2.5SiO2:1H2O)0.2(gel) + 0.5H<+> = 0.7H2O(l) + 0.2SiO2(aq) + 0.5K<+>
+    # Editor: Miron
+    log_k     5.8
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: KUL/TIT2007
+    # Description: Additional reference: LOT/LE 2012
+    -analytical_expression     -3.80024310273655E+0   0      1.02558587761614E+3      2.48962356170117E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 12.4 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: KUL/TIT2007
+
+CSHQ_NaSiOH
+    # Synonyms: CSHQ_NaSiOH_ss
+    (NaOH)0.5(SiO2)0.2:0.2H2O + 0.5 H+ = 0.3 H2O + 0.5 Na+ + 0.2 Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, NaSiOH
+    # Original equation: ((NaOH)2.5SiO2:1H2O)0.2(gel) + 0.5H<+> = 0.5Na<+> + 0.7H2O(l) + 0.2SiO2(aq)
+    # Editor: Miron
+    log_k     5.7
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: KUL/TIT2007
+    # Description: Additional reference: LOT/LE 2012
+    -analytical_expression     -9.80321968699123E+0   0      1.54332779314372E+3      4.17342693676477E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 10.5 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: KUL/TIT2007
+
+CSHQ_TobD
+    # Synonyms: CSHQ_TobD_ss
+    (CaO)0.83333(SiO2)0.66667:1.83333H2O + 1.66666 H+ = 0.83333 Ca+2 + 1.33332 H2O + 0.66667 Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, CSHQ-TobD
+    # Original equation: ((CaO)1.25SiO2:2.75H2O)0.6667(gel) + 1.66675H<+> = 0.833375Ca<2+> + 2.6668H2O(l) + 0.6667SiO2(aq)
+    # Editor: Miron
+    log_k     13.656
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: KUL2011
+    # Description: Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      -1.0916686881375E+1   0      3.95936941034506E+3      4.56382877644023E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 48 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: KUL2011
+
+CSHQ_TobH
+    # Synonyms: CSHQ_TobH_ss
+    (CaO)0.6667(SiO2):1.5H2O + 1.3334 H+ = 0.6667 Ca+2 + 0.1667 H2O + Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, CSHQ-TobH
+    # Original equation: (CaO)0.6667(SiO2):1.5H2O(gel) + 1.3334H<+> = 0.6667Ca<2+> + 2.1667H2O(l) + SiO2(aq)
+    # Editor: Miron
+    log_k     8.288
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: KUL2011
+    # Description: Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      -1.2518840881665E+1   0      2.16338219652249E+3      5.47632993405503E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 55 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: KUL2011
+
+CsMgCl3:6H2O(s)
+    CsMgCl3:6H2O = 3 Cl- + Cs+ + 6 H2O + Mg+2
+    # Editor: Moog
+    log_k     4.06
+    # Evaluation data class: 1, data quality: 3
+    # Reference: SCH/MUN2013
+
+CsNa2Cl3:2H2O(cr)
+    # Synonyms: 
+    # Description: Solid-solution between CsCl(cr) and CsCl2NaCl2H2O(cr)
+    CsNa2Cl3:2H2O = 3 Cl- + Cs+ + 2 H2O + 2 Na+
+    # Description: Phase constitutent for the double salt CsCl2NaCl2H2O(cr) as end-member of the ideal solid-solution (Cs,Na)Cl:H2O(cr)
+    # Original equation: Cs<+> + 2Na<+> + 3Cl<-> + 2H2O(l) = CsCl:2NaCl:2H2O(cr)
+    # Editor: Bok
+    log_k     4.288
+    # Evaluation data class: 1, data quality: 1
+    # Reference: BOK2023
+    # Description: LOGK is valid only as part of the solid-solution between the end-members CsCl(cr) and CsNa2Cl3:2H2O(cr)!
+
+Dansite
+    # Synonyms: D'Ansite 
+    MgNa21Cl3(SO4)10 = 3 Cl- + Mg+2 + 21 Na+ + 10 SO4-2
+    # Editor: Freyer
+    log_k     0.96927588612536
+    # Notice: value was extrapolated from tp function
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      1.38961698196574E+3     -3.94108728975862E+0     -1.59416291871877E+5   0   0      3.61187953385182E-3 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 313.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+Dolomite
+    # Synonyms: Miemite, Muricalcite, Ridolphite, Tharandite
+    CaMg(CO3)2 = 2 CO3-2 + Ca+2 + Mg+2
+    # Editor: Freyer
+    log_k     -18.930997299721
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      2.70258669437289E+2   0     -1.17379385733094E+4     -1.00960610980817E+2   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 64.475804 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: EFF/MER1981
+
+ECSH-1_KSH
+    (KOH)0.5(SiO2)0.2:0.2H2O + 0.5 H+ = 0.3 H2O + 0.5 K+ + 0.2 Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, ECSH1-KSH, provisional data
+    # Original equation: ((KOH)2.5SiO2:1H2O)0.2(gel) + 0.5H<+> = 0.7H2O(l) + 0.2SiO2(aq) + 0.5K<+>
+    # Editor: Miron
+    log_k     5.5
+    # Evaluation data class: 1, data quality: 2
+    # Reference: LOT/KUL2019
+    # Additional reference: KUL/TIT2007
+    # Description: provisional data
+    -analytical_expression     -5.73055233335947E+0   0      1.10882495251719E+3      3.03565694190037E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 12.4 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: KUL/TIT2007
+
+ECSH-1_NaSH
+    (NaOH)0.5(SiO2)0.2:0.2H2O + 0.5 H+ = 0.3 H2O + 0.5 Na+ + 0.2 Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, ECSH1-NaSH, provisional data
+    # Original equation: ((NaOH)2.5SiO2:1H2O)0.2(gel) + 0.5H<+> = 0.5Na<+> + 0.7H2O(l) + 0.2SiO2(aq)
+    # Editor: Miron
+    log_k     5.41
+    # Evaluation data class: 1, data quality: 2
+    # Reference: LOT/KUL2019
+    # Additional reference: KUL/TIT2007
+    # Description: provisional data. exact value was used instead of rounded value given in the reference.
+    -analytical_expression     -1.26092859689057E+1   0      1.57521750316189E+3      5.14702610256046E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 10.5 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: KUL/TIT2007
+
+ECSH-1_SH
+    SiO2:1H2O + H2O = Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, ECSH1-SH, provisional data
+    # Original equation: SiO2:1H2O(gel) = H2O(l) + SiO2(aq)
+    # Editor: Miron
+    log_k     -2.6
+    # Evaluation data class: 1, data quality: 3
+    # Reference: LOT/KUL2019
+    # Additional reference: KUL/KER2001
+    # Description: provisional data
+    -analytical_expression      -3.3448954638817E-4   0     -7.75090271941744E+2   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 34 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: KUL/KER2001
+
+ECSH-1_TobCa
+    (Ca(OH)2)0.8333SiO2:1H2O + 1.6666 H+ = 0.8333 Ca+2 + 0.6666 H2O + Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, ECSH1-TobCa, provisional data
+    # Original equation: (Ca(OH)2)0.8333SiO2:1H2O(gel) + 1.6666H<+> = 0.8333Ca<2+> + 2.6666H2O(l) + SiO2(aq)
+    # Editor: Miron
+    log_k     11.021
+    # Evaluation data class: 1, data quality: 2
+    # Reference: LOT/KUL2019
+    # Additional reference: KUL/KER2001
+    # Description: provisional data. exact value was used instead of rounded value given in the reference.
+    -analytical_expression     -1.37771257809409E+1   0      3.02321665438689E+3      5.92386081681301E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 68 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: KUL/KER2001
+
+ECSH-2_JenCa
+    Ca(OH)2(SiO2)0.6:0.6H2O + 2 H+ = Ca+2 + 1.4 H2O + 0.6 Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, ECSH2-JenCa, provisional data
+    # Original equation: ((Ca(OH)2)1.6667SiO2:1H2O)0.6(gel) + 2.00004H<+> = 1.00002Ca<2+> + 2.60004H2O(l) + 0.6SiO2(aq)
+    # Editor: Miron
+    log_k     17.605
+    # Evaluation data class: 1, data quality: 2
+    # Reference: LOT/KUL2019
+    # Additional reference: KUL/KER2001
+    # Description: provisional data. exact value was used instead of rounded value given in the reference.
+    -analytical_expression     -2.29775325673925E+1   0      5.25002281535139E+3      9.28449181010066E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 36 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: KUL/KER2001
+
+ECSH-2_KSH
+    (KOH)0.5(SiO2)0.2:0.2H2O + 0.5 H+ = 0.3 H2O + 0.5 K+ + 0.2 Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, ECSH2-KSH, provisional data
+    # Original equation: ((KOH)2.5SiO2:1H2O)0.2(gel) + 0.5H<+> = 0.7H2O(l) + 0.2SiO2(aq) + 0.5K<+>
+    # Editor: Miron
+    log_k     6.0
+    # Evaluation data class: 1, data quality: 2
+    # Reference: LOT/KUL2019
+    # Additional reference: KUL/TIT2007
+    # Description: provisional data. exact value was used instead of rounded value given in the reference.
+    -analytical_expression     -5.73089903447515E+0   0      1.25800332145483E+3      3.03565694190037E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 12.4 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: KUL/TIT2007
+
+ECSH-2_NaSH
+    (NaOH)0.5(SiO2)0.2:0.2H2O + 0.5 H+ = 0.3 H2O + 0.5 Na+ + 0.2 Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, ECSH2-NaSH, provisional data
+    # Original equation: ((NaOH)2.5SiO2:1H2O)0.2(s) + 0.5H<+> = 0.5Na<+> + 0.7H2O(l) + 0.2SiO2(aq)
+    # Editor: Miron
+    log_k     5.909
+    # Evaluation data class: 1, data quality: 2
+    # Reference: LOT/KUL2019
+    # Additional reference: KUL/TIT2007
+    # Description: provisional data. exact value was used instead of rounded value given in the reference.
+    -analytical_expression     -1.26094063300677E+1   0      1.72403023884232E+3      5.14702610256046E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 10.5 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: KUL/TIT2007
+
+ECSH-2_TobCa
+    (Ca(OH)2)0.8333SiO2:1H2O + 1.6666 H+ = 0.8333 Ca+2 + 0.6666 H2O + Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, ECSH2-TobCa, provisional data
+    # Original equation: (Ca(OH)2)0.8333SiO2:1H2O(gel) + 1.6666H<+> = 0.8333Ca<2+> + 2.6666H2O(l) + SiO2(aq)
+    # Editor: Miron
+    log_k     11.021
+    # Evaluation data class: 1, data quality: 2
+    # Reference: LOT/KUL2019
+    # Additional reference: KUL/KER2001
+    # Description: provisional data. exact value was used instead of rounded value given in the reference.
+    -analytical_expression     -1.37771257809409E+1   0      3.02321665438689E+3      5.92386081681301E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 68 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: KUL/KER2001
+
+Eitelite
+    MgNa2(CO3)2 = 2 CO3-2 + Mg+2 + 2 Na+
+    # Editor: Freyer
+    log_k     -7.9444153883333
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      2.44385384373129E+2   0     -9.00608028982605E+3      -8.9767274039329E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+Epsomite
+    # Synonyms: Bitter Salt, Epsom Salt, Reichardite, Seelandite
+    Mg(SO4):7H2O = 7 H2O + Mg+2 + SO4-2
+    # Editor: Freyer
+    log_k     -1.8811216585226
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression     -7.66223014780849E+0      3.16298859540048E-2   0   0   0     -4.10530292087674E-5 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 343.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 147.061193 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: FER/JON1973
+
+Ettringite-H2O_ettringite30
+    Ca6Al2(SO4)3(OH)12:24H2O + 4 H+ = 2 Al(OH)4- + 6 Ca+2 + 28 H2O + 3 SO4-2
+    # Description: Original reaction from LOT/KUL2019, Table B2, ettringite30. Thermodynamic data from hydration-dehydration experiments.
+    # Original equation: Ca6Al2(SO4)3(OH)12:24H2O(cr) + 4H<+> = 2AlO2<-> + 6Ca<2+> + 3SO4<2-> + 32H2O(l)
+    # Editor: Miron
+    log_k     11.762
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: BAQ/MAT2016
+    # Description: Thermodynamic data from hydration-dehydration experiments. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      2.72821744075519E+2   0     -9.99355788593848E+3     -9.19568320923301E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 707.8 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: BAQ/MAT2016
+
+Ettringite-H2O_ettringite32
+    Ca6Al2(SO4)3(OH)12:26H2O + 4 H+ = 2 Al(OH)4- + 6 Ca+2 + 30 H2O + 3 SO4-2
+    # Description: Original reaction from LOT/KUL2019, Table B2, ettringite
+    # Original equation: Ca6Al2(SO4)3(OH)12:26H2O(s) + 4H<+> = 2AlO2<-> + 6Ca<2+> + 3SO4<2-> + 34H2O(l)
+    # Editor: Miron
+    log_k     11.161
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: LOT/MAT2008
+    # Description: Additional reference: MAT/LOT2007. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      2.49812818442945E+2   0     -9.57542892263253E+3     -8.34678171052773E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 707.8 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: LOT/MAT2008
+
+Friedels_salt
+    # Synonyms: Friedel's Salt
+    Ca4Al2Cl2(OH)12:4H2O + 4 H+ = 2 Al(OH)4- + 4 Ca+2 + 2 Cl- + 8 H2O
+    # Description: Original reaction from LOT/KUL2019, Table B2, C4AClH10
+    # Original equation: Ca4Al2Cl2(OH)12:4H2O(s) + 4H<+> = 2AlO2<-> + 4Ca<2+> + 2Cl<-> + 12H2O(l)
+    # Editor: Miron
+    log_k     28.887
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: BAL/GLA2009
+    # Description: Additional reference: BAL2010. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      1.33572575534873E+2   0      3.52518809715824E+3     -4.70851559502605E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+    -Vm 272 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: BAL/LOT2010
+
+Gaylussite
+    # Synonyms: Gaylussacite, Gay-Lussite
+    CaNa2(CO3)2:5H2O = 2 CO3-2 + Ca+2 + 5 H2O + 2 Na+
+    # Editor: Freyer
+    log_k     -9.4319528167316
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression     -3.98176184090577E+0   0     -1.62497866164214E+3      5.72305523716971E-6   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 348.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 148.67055148594 cm3/mol
+    # Reference: NotYetDetermined
+
+Gibbsite
+    # Synonyms: b-Kliachite, Claussenite, Hydrargillite, Hydrargyllite, Zirlite
+    # Description: Crystalline form of Al(OH)3 assumed to be the stable form in cementitious systems. However, microcrystalline or amorphous forms may be relevant as well (see REA1992, MAT/LOT2007, HUM/BER2002).
+    Al(OH)3 + H2O = Al(OH)4- + H+
+    # Editor: Miron
+    log_k     -15.11556934429
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression                 -1.78E+0   0                -3.976E+3   0   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 373.15 K.
+    # Reference: MIR2023
+    # Additional reference: BRO/EKB2016
+
+Glaserite
+    # Synonyms: Aphtalite, Aphthitalite, Vesuvian Salt
+    K6Na2(SO4)4 = 6 K+ + 2 Na+ + 4 SO4-2
+    # Editor: Freyer
+    log_k     -7.6052643462747
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression     -4.27045468969485E+1      1.95126014590115E-1   0   0   0     -2.59609172392461E-4 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 250.308637 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: ROS/KOC1968
+
+Glauberite
+    # Synonyms: 
+    CaNa2(SO4)2 = Ca+2 + 2 Na+ + 2 SO4-2
+    # Editor: Freyer
+    log_k     -5.2156230382493
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      1.95793686638689E+2   0     -8.29563275846862E+3     -6.99899736231885E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 373.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 97.607978 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: ROS/KOC1968
+
+Goergeyite
+    # Synonyms: Görgeyite, Mikheevite, Mikheyevite, Pentasalt
+    Ca5K2(SO4)6:H2O = 5 Ca+2 + H2O + 2 K+ + 6 SO4-2
+    # Editor: Freyer
+    log_k     -25.307228002405
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression       5.9687925355597E+2   0     -2.66937987415249E+4     -2.15263315456954E+2   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 315.15432490975 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: ROS/KOC1968
+
+Goslarite
+    Zn(SO4):7H2O = 7 H2O + SO4-2 + Zn+2
+    # Editor: Moog
+    log_k     -1.9744
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG2022
+
+Grimselite
+    K3Na(UO2(CO3)3):H2O = 3 CO3-2 + H2O + 3 K+ + Na+ + UO2+2
+    # Original equation: NaK3UO2(CO3)3:H2O = Na<+> + 3K<+> + UO2<2+> + 3CO3<2-> + H2O
+    # Editor: Bok
+    log_k     -37.1
+    # Evaluation data class: 1, data quality: 2
+    # Reference: GOR/BUR2008
+    # Additional reference: OBR/WIL1983
+    # Description: Ksp calculated from reported standard state Gibbs free energy of formation from OBR/WIL1983 by GOR/BUR2008.
+
+Gypsum
+    # Synonyms: Gypsite, Montmartrite, Oulopholite
+    Ca(SO4):2H2O = Ca+2 + 2 H2O + SO4-2
+    # Editor: Freyer
+    log_k     -4.5558534536207
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression       6.4988020828832E+3      3.84778883651487E+0     -1.32242254053427E+5     -2.84045580512238E+3   0     -2.00814361770676E-3 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 74.53297 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: PED/SEM1982
+
+Haiweeite
+    # Synonyms: Gastunite, Ranquilite
+    Ca((UO2)2(Si2O5)3):5H2O + 4 H2O + 6 H+ = Ca+2 + 6 Si(OH)4 + 2 UO2+2
+    # Editor: Richter
+    log_k     -5.52
+    # Evaluation data class: 3, data quality: 3
+    # Reference: HEM1982
+    # Description: ATTENTION: [HEM1982] estimated DFG298=-9396+-25kJ/mol; no logK from solubility experiments are available, the here entered logK is calculated from DFG!, otherwise the mineral is relevant, and so the logK should be used with reservation; no neutral complex
+
+Halite
+    # Synonyms: Rock Salt, Sodium Chloride
+    NaCl = Cl- + Na+
+    # Editor: Freyer
+    log_k     1.592782686663
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      1.96472026306316E+3       5.8019872356981E-1     -8.28218302658124E+4     -7.61045446629381E+2      3.76043774076606E+6     -1.96565354516397E-4 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 480.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 26.932152 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: BAR/WAL1954
+
+Hemicarboaluminate
+    # Synonyms: Hemicarbonat
+    Ca4Al2(CO3)0.5(OH)13:5.5H2O + 5 H+ = 2 Al(OH)4- + 0.5 CO3-2 + 4 Ca+2 + 10.5 H2O
+    # Description: Original reaction from LOT/KUL2019, Table B2, hemicarbonate
+    # Original equation: (CaO)3Al2O3(CaCO3)0.5(CaO2H2)0.5:11.5H2O(s) + 5H<+> = 2AlO2<-> + 0.5CO3<2-> + 4Ca<2+> + 14.5H2O(l)
+    # Editor: Miron
+    log_k     40.879
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: LOT/MAT2008
+    # Description: Additional reference: MAT/LOT2007. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      6.22697304934517E+1   0      9.54977554224582E+3     -2.15891255167172E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+    -Vm 284.5 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: LOT/MAT2008
+
+Hemicarboaluminate_10.5H2O
+    Ca4Al2C0.5O8:10.5H2O + 5 H+ = 2 Al(OH)4- + 0.5 CO3-2 + 4 Ca+2 + 9 H2O
+    # Description: Original reaction from LOT/KUL2019, Table B2, hemicarbonat10.5. Thermodynamic data from hydration-dehydration experiments.
+    # Original equation: (CaO)3Al2O3(CaCO3)0.5(CaO2H2)0.5:10H2O(cr) + 5H<+> = 2AlO2<-> + 0.5CO3<2-> + 4Ca<2+> + 13H2O(l)
+    # Editor: Miron
+    log_k     42.61
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: BAQ/MAT2015
+    # Description: Thermodynamic data from hydration-dehydration experiments. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression       7.7626343970132E+1   0      1.01841872641234E+4     -2.79555860778327E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 261.3 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: BAQ/MAT2015
+
+Hemicarboaluminate_9H2O
+    Ca4Al2C0.5O8:9H2O + 5 H+ = 2 Al(OH)4- + 0.5 CO3-2 + 4 Ca+2 + 7.5 H2O
+    # Description: Original reaction from LOT/KUL2019, Table B2, hemicarbonate9. Thermodynamic data from hydration-dehydration experiments.
+    # Original equation: (CaO)3Al2O3(CaCO3)0.5(CaO2H2)0.5:8.5H2O(cr) + 5H<+> = 2AlO2<-> + 0.5CO3<2-> + 4Ca<2+> + 11.5H2O(l)
+    # Editor: Miron
+    log_k     45.609
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: BAQ/MAT2015
+    # Description: Thermodynamic data from hydration-dehydration experiments. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      9.30587317447537E+1   0      1.11738689587623E+4     -3.43218060956088E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 249.3 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: BAQ/MAT2015
+
+Hexahydrite
+    Mg(SO4):6H2O = 6 H2O + Mg+2 + SO4-2
+    # Editor: Freyer
+    log_k     -1.6350970920879
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression     -5.41426942014839E+0      2.59249767422235E-2   0   0   0     -4.44392998165232E-5 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 132.825163 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: ZAL/RUB1964
+
+Hinsdalite
+    PbAl3(PO4)(SO4)(OH)6 + 6 H2O = 3 Al(OH)4- + 6 H+ + PO4-3 + Pb+2 + SO4-2
+    # Editor: Moog
+    log_k     -86.2
+    # Evaluation data class: 1, data quality: 3
+    # Reference: MOO2022
+
+Huntite
+    CaMg3(CO3)4 = 4 CO3-2 + Ca+2 + 3 Mg+2
+    # Editor: Freyer
+    log_k     -30.712275882481
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression     -1.02958270391381E+3   0      4.91999836624213E+4      3.36987191051778E+2   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 122.579375 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: SAN/OTE2019
+
+Hydrocerussite
+    (PbCO3)2Pb(OH)2 + 2 H+ = 2 CO3-2 + 2 H2O + 3 Pb+2
+    # Editor: Moog
+    log_k     -18.6
+    # Evaluation data class: 1, data quality: 1
+    # Reference: MOO2022
+
+Hydrogarnet
+    # Synonyms: Hydrogranat
+    Ca3Al2(OH)12 + 4 H+ = 2 Al(OH)4- + 3 Ca+2 + 4 H2O
+    # Description: Original reaction from LOT/KUL2019, Table B2, C3AH6
+    # Original equation: Ca3Al2O6:6H2O(s) + 4H<+> = 2AlO2<-> + 3Ca<2+> + 8H2O(l)
+    # Editor: Miron
+    log_k     35.505
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: DIL/LOT2014
+    # Description: Additional reference: LOT/PEL2012. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      6.92660452238689E+0   0      1.14988836308934E+4     -4.03691859171497E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+    -Vm 150 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: DIL/LOT2014
+
+Hydromagnesite
+    # Synonyms: Hydromagnocalcite, Idromagnesite
+    Mg5(CO3)4(OH)2:4H2O + 2 H+ = 4 CO3-2 + 6 H2O + 5 Mg+2
+    # Description: from THEREDA Journal Voigt
+    # Editor: Freyer
+    log_k     -10.309511481606
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression        4.545328293635E+2   0     -1.02657406092173E+4     -1.73943111431836E+2   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 207.8384 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: AKA/IWA1977a
+
+Hydrotalcite
+    # Synonyms: Völcknerite, Volkermite, Völkernite
+    Mg4Al2(OH)14:3H2O + 6 H+ = 2 Al(OH)4- + 9 H2O + 4 Mg+2
+    # Description: Original reaction from LOT/KUL2019, Table B2, hydrotalcite. Tentative value, recommended for PC based systems.
+    # Original equation: Mg4Al2O7:10H2O(s) + 6H<+> = 2AlO2<-> + 4Mg<2+> + 13H2O(l)
+    # Editor: Miron
+    log_k     27.988
+    # Evaluation data class: 1, data quality: 3
+    # Reference: LOT/KUL2019
+    # Additional reference: LOT/MAT2008
+    # Description: Additional reference: LOT/WIN2006. Tentative value. recommended for PC based systems. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression     -6.44084262560327E+1   0      1.45584232123571E+4      1.76069305346918E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+    -Vm 220 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: LOT/MAT2008
+
+Hydroxylapatite
+    # Synonyms: Apatite-(CaOH), Hydro-apatite, Hydroxyapatite, Monite
+    Ca5(OH)(PO4)3 + H+ = 5 Ca+2 + H2O + 3 PO4-3
+    # Editor: Moog
+    log_k     -44.3
+    # Evaluation data class: 1, data quality: 2
+    # Reference: SCH2017
+
+Hydrozincite_nat(s)
+    Zn5(CO3)2(OH)6 + 6 H+ = 2 CO3-2 + 6 H2O + 5 Zn+2
+    # Original equation: 2ZnCO33Zn(OH)2= 5Zn2++2CO32-+6OH- (logK = -77.6 +- 0.5)
+    # Editor: Moog
+    log_k     6.41
+    # Evaluation data class: 1, data quality: 3
+    # Reference: HAG2022
+
+Hydrozincite_synth(s)
+    Zn5(CO3)2(OH)6 + 6 H+ = 2 CO3-2 + 6 H2O + 5 Zn+2
+    # Original equation: 2ZnCO33Zn(OH)2= 5Zn2++2CO32-+6OH- (logK = -74.8 +- 0.4)
+    # Editor: Moog
+    log_k     9.21
+    # Evaluation data class: 1, data quality: 3
+    # Reference: HAG2022
+
+Ikaite
+    # Description: hexahydrate of CaCO3
+    Ca(CO3):6H2O = CO3-2 + Ca+2 + 6 H2O
+    # Editor: Freyer
+    log_k     -6.5829464458211
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      1.61923494365275E-1   0     -2.01098533324616E+3    -2.56178964459679E-12   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 298.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+K(H2PO4)(cr)
+    K(H2PO4) = 2 H+ + K+ + PO4-3
+    # Editor: Moog
+    log_k     -20.0
+    # Evaluation data class: 1, data quality: 1
+    # Reference: SCH/MUN2013a
+
+K-alum
+    # Description: KAl(SO4)2:12H2O
+    KAl(SO4)2:12H2O = Al(OH)4- + 8 H2O + 4 H+ + K+ + 2 SO4-2
+    # Editor: Miron
+    log_k     -29.7113
+    # Evaluation data class: 1, data quality: 1
+    # Reference: MIR2023
+
+K-Autunite
+    K(UO2PO4):3H2O = 3 H2O + K+ + PO4-3 + UO2+2
+    # Editor: Bok
+    log_k     -25.5
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GRE/GAO2020
+
+K-Compreignacite
+    K2U6O19:11H2O + 14 H+ = 18 H2O + 2 K+ + 6 UO2+2
+    # Description: original reaction from [CEV/YAL2018]: 1/3K<+> + UO2<2+> + 3H2O(l) = 1/6K2U6O19:11H2O(cr) + 7/3H<+> with logK=-6.3+-0.1; alternative formula K2(UO2)6O4(OH)6:8H2O(cr)
+    # Original equation: 1/3K<+> + UO2<2+> + 3H2O(l) = 1/6K2U6O19:11H2O(cr) + 7/3H<+>
+    # Editor: Richter
+    log_k     37.8
+    # Evaluation data class: 1, data quality: 1
+    # Reference: CEV/YAL2018
+    # Description: original formation reaction in [CEV/YAL2018]: 1/3K<+> + UO2<2+> + 3H2O(l) = 1/6K2U6O19:11H2O(cr) + 7/3H<+> with logK=-6.3+-0.1; value re-evaluated from experimental data in [SAN/GRA1994]
+
+K2(CO3):1.5H2O(cr)
+    K2(CO3):1.5H2O = CO3-2 + 1.5 H2O + 2 K+
+    # Editor: Freyer
+    log_k     3.0475856529737
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -Vm 80.875389133627 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: GRO1908
+
+K2(HPO4):3H2O(cr)
+    K2(HPO4):3H2O = 3 H2O + H+ + 2 K+ + PO4-3
+    # Editor: Moog
+    log_k     -11.45
+    # Evaluation data class: 1, data quality: 1
+    # Reference: SCH/MUN2013a
+
+K2(SeO3)(cr)
+    K2(SeO3) = 2 K+ + SeO3-2
+    # Editor: Bok
+    log_k     4.1829221996049
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression              -2.94412E+1              -3.26336E-2   0      1.75206999998105E+1   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 353.15 K.
+    # Reference: BOK2021
+
+K2(SeO3):4H2O(cr)
+    K2(SeO3):4H2O = 4 H2O + 2 K+ + SeO3-2
+    # Editor: Bok
+    log_k     2.631828499
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression               2.23545E+0               1.32946E-3   0   0   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 298.15 K.
+    # Reference: BOK2021
+
+K2(SeO4)(cr)
+    K2(SeO4) = 2 K+ + SeO4-2
+    # Original equation: K2SeO4(cr) <=> 2 K<+> + SeO4<2->
+    # Editor: Bok
+    log_k     1.3175462694967
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -analytical_expression              -2.85151E+0               2.98887E-2   0   0   0              -5.33477E-5 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: BOK2021
+
+K2Mg(SeO4)2:6H2O(cr)
+    K2Mg(SeO4)2:6H2O = 6 H2O + 2 K+ + Mg+2 + 2 SeO4-2
+    # Original equation: K2Mg(SeO4)2:6H2O(cr) <=> 2 K<+> + Mg<2+> + 2 SeO4<2-> + 6 H2O(l)
+    # Editor: Bok
+    log_k     -2.868
+    # Evaluation data class: 1, data quality: 2
+    # Reference: HAG/MOO2012
+
+K2U2O7:1.5H2O(cr)
+    K2U2O7:1.5H2O + 6 H+ = 4.5 H2O + 2 K+ + 2 UO2+2
+    # Editor: Richter
+    log_k     24.0
+    # Evaluation data class: 1, data quality: 1
+    # Reference: CEV/YAL2018
+    # Description: original formation reaction in [ALT/YAL2017]: K<+> + UO2<2+> + 2.25 H2O(l) = 0.5 K2U2O7:H2O(cr) + 3H<+> with logK=-12.0+-0.2
+
+K2Zn(SO4)2:6H2O(cr)
+    K2Zn(SO4)2:6H2O = 6 H2O + 2 K+ + 2 SO4-2 + Zn+2
+    # Editor: Moog
+    log_k     -5.95
+    # Evaluation data class: 1, data quality: 3
+    # Reference: HAG2022
+
+K3(HSO4)(SO4)(cr)
+    K3(HSO4)(SO4) = H+ + 3 K+ + 2 SO4-2
+    # Editor: Freyer
+    log_k     -3.5042494302119
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      1.16442751398083E+4      6.08813187442722E+0     -2.54992940255613E+5     -4.99463519153286E+3   0     -2.79892699484941E-3 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 348.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+K3(PO4):7H2O(cr)
+    K3(PO4):7H2O = 7 H2O + 3 K+ + PO4-3
+    # Editor: Moog
+    log_k     0.282
+    # Evaluation data class: 1, data quality: 2
+    # Reference: SCH/MUN2013a
+
+K3NpO2(CO3)2(s)
+    K3NpO2(CO3)2 = 2 CO3-2 + 3 K+ + NpO2+
+    # Editor: Marquardt
+    log_k     -15.46
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Additional reference: ALT/BRE2004
+
+K8(HCO3)4(CO3)2:3H2O(cr)
+    K8(CO3)2(HCO3)4:3H2O = 6 CO3-2 + 3 H2O + 4 H+ + 8 K+
+    # Editor: Freyer
+    log_k     -34.338209671073
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+
+Kainite
+    # Synonyms: Caenite, Cenite
+    K4Mg4Cl4(SO4)4:11H2O = 4 Cl- + 11 H2O + 4 K+ + 4 Mg+2 + 4 SO4-2
+    # Editor: Freyer
+    log_k     -0.51446615105441
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      1.14985948876986E+5       6.7804145090787E+1     -2.33234331528658E+6     -5.02161356351728E+4   0     -3.51319262899331E-2 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 454.81101395349 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: ROS/KOC1968
+
+Kalicinite
+    # Synonyms: Kalicine, Potassium Bicarbonate
+    K(HCO3) = CO3-2 + H+ + K+
+    # Editor: Freyer
+    log_k     -10.044037112805
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -Vm 46.392557924004 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: GRO1908
+
+Kieserite
+    Mg(SO4):H2O = H2O + Mg+2 + SO4-2
+    # Editor: Freyer
+    log_k     -0.12268656579453
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      5.03296596616607E+0     -1.05660461365627E-2   0   0   0     -2.25594421668463E-5 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 473.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 53.636775 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: TAL/BAL2020
+
+KNa(CO3):6H2O(cr)
+    KNa(CO3):6H2O = CO3-2 + 6 H2O + K+ + Na+
+    # Editor: Freyer
+    log_k     -0.11120671826899
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+
+KNa(HPO4):5H2O(cr)
+    KNa(HPO4):5H2O = 5 H2O + H+ + K+ + Na+ + PO4-3
+    # Description: Original reaction equations logK= 0.935
+    # Original equation: K<+> + Na<+> + HPO4<2-> + 5 H2O = KNa(HPO4):5H2O(cr)
+    # Editor: Bok
+    log_k     -13.285
+    # Evaluation data class: 1, data quality: 1
+    # Reference: SCH/MUN2015
+    # Description: Original equation: K<+> + Na<+> + HPO4<2-> + 5H2O = KNaHPO4:5H2O(cr) log K = 0.935
+
+KNpO2(CO3)_hyd(s)
+    KNpO2(CO3) = CO3-2 + K+ + NpO2+
+    # Editor: Marquardt
+    log_k     -13.15
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+Kuzels_salt
+    # Synonyms: Kuzels salt, Kuzelite
+    Ca4Al2(SO4)0.5Cl(OH)12:6H2O + 4 H+ = 2 Al(OH)4- + 4 Ca+2 + Cl- + 10 H2O + 0.5 SO4-2
+    # Description: Original reaction from LOT/KUL2019, Table B2, C4AsClH12
+    # Original equation: Ca4Al2Cl(SO4)0.5(OH)12:6H2O(s) + 4H<+> = 2AlO2<-> + 4Ca<2+> + Cl<-> + 0.5SO4<2-> + 14H2O(l)
+    # Editor: Miron
+    log_k     27.58
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: BAL/LOT2010
+    # Description: Additional reference: BAL/GLA2009. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      1.19687731838684E+2   0      3.70696540016637E+3     -4.22484307553902E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+    -Vm 289 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: BAL/LOT2010
+
+Labile-salt
+    CaNa4(SO4)3:2H2O = Ca+2 + 2 H2O + 4 Na+ + 3 SO4-2
+    # Editor: Freyer
+    log_k     -5.6124524577299
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      1.58861516124656E+2   0     -6.66719295569303E+3     -5.74321456359373E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 348.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+Lanarkite
+    (PbO)(PbSO4) + 2 H+ = H2O + 2 Pb+2 + SO4-2
+    # Editor: Moog
+    log_k     0.51
+    # Evaluation data class: 1, data quality: 3
+    # Reference: MOO2022
+    # Description: Determined from equilibrium with Anglesite [CHA1956a,CHA1956b,CHA1956c]
+
+Langbeinite
+    K2Mg2(SO4)3 = 2 K+ + 2 Mg+2 + 3 SO4-2
+    # Editor: Freyer
+    log_k     -0.14452252851762
+    # Notice: value was extrapolated from tp function
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression     -1.55593514975028E+5     -4.91841317437346E+1      6.32155057702637E+6      6.08992500171388E+4     -2.81208165364635E+8      1.71805844226079E-2 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 323.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 146.90067256637 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: ROS/KOC1968
+
+Lansfordite
+    Mg(CO3):5H2O = CO3-2 + 5 H2O + Mg+2
+    # Editor: Freyer
+    log_k     -5.0388658424423
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      1.13825289298962E+2   0     -5.41978177147701E+3     -4.06905518184476E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 303.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 103.18952662722 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: LIU/ZHO1990
+
+Laurionite
+    Pb(OH)Cl + H+ = Cl- + H2O + Pb+2
+    # Description: Solubility studies in high-saline solutions so far unknown
+    # Editor: Moog
+    log_k     0.3
+    # Evaluation data class: 1, data quality: 1
+    # Reference: MOO2022
+
+Lazaridisite
+    # Synonyms: Lazaridisite
+    Cd3(SO4)3:8H2O = 3 Cd+2 + 8 H2O + 3 SO4-2
+    # Editor: Moog
+    log_k     -5.858
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG2024
+
+Lead
+    Pb + 2 H+ = H2 + Pb+2
+    # Editor: Moog
+    log_k     4.2462716407323
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CF
+    -analytical_expression      4.40744774893486E+0   0     -4.80546566605839E+1   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+
+Leadhillite
+    Pb4(SO4)(CO3)2(OH)2 + 2 H+ = 2 CO3-2 + 2 H2O + 4 Pb+2 + SO4-2
+    # Editor: Moog
+    log_k     -26.9
+    # Evaluation data class: 1, data quality: 3
+    # Reference: MOO2022
+
+Leonite
+    K2Mg(SO4)2:4H2O = 4 H2O + 2 K+ + Mg+2 + 2 SO4-2
+    # Editor: Freyer
+    log_k     -3.9789533693926
+    # Notice: value was extrapolated from tp function
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression     -5.56275771476578E+1      1.99936493702675E-1      4.16259609725346E+3   0   0     -2.46630872220853E-4 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 313.15 K - 343.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 166.676327 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: HER/GIE2001
+
+Liebigite
+    Ca2(UO2(CO3)3):10H2O = 3 CO3-2 + 2 Ca+2 + 10 H2O + UO2+2
+    # Original equation: Ca2UO2(CO3)3:10H2O = 2Ca<2+> + UO2<2+> + 3CO3<2-> + 10H2O
+    # Editor: Bok
+    log_k     -36.9
+    # Evaluation data class: 1, data quality: 2
+    # Reference: GOR/BUR2008
+    # Additional reference: ALW/WIL1980
+    # Description: Ksp calculated from reported standard state Gibbs free energy of formation from ALW/WIL1980 by GOR/BUR2008.
+
+Litharge
+    # Synonyms: Red Lead oxide, Litargia
+    PbO + 2 H+ = H2O + Pb+2
+    # Description: Applicability for calculations for high-saline solutions to be determined
+    # Original equation: PbO_red(s) + 2H+ = Pb+2 + H2O
+    # Editor: Moog
+    log_k     12.91
+    # Evaluation data class: 1, data quality: 2
+    # Reference: MOO2022
+    -analytical_expression      1.43477114317329E+0   0       3.4213348542662E+3   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+
+Loeweite
+    # Synonyms: Loewite
+    Mg7Na12(SO4)13:15H2O = 15 H2O + 7 Mg+2 + 12 Na+ + 13 SO4-2
+    # Editor: Freyer
+    log_k     -11.039706545665
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      1.73630327279346E+2     -3.70070026542458E-1     -2.21625793609022E+4   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 832.65052176271 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: FAN/ROB1970
+
+Magnesite_nat(cr)
+    # Synonyms: Magnesite
+    # Description: 
+    Mg(CO3) = CO3-2 + Mg+2
+    # Editor: Freyer
+    log_k     -8.9115126261436
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      1.30368104854368E+2   0     -5.12140936360499E+3     -4.93455417096137E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 27.76223246625 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: GRO1908
+
+Magnesite_ss(cr)
+    Mg(CO3) = CO3-2 + Mg+2
+    # Editor: Freyer
+    log_k     5.955
+    # Evaluation data class: 3, data quality: 1
+    # Reference: VOI2023
+
+Magnesite_syn(cr)
+    # Synonyms: Bandisserite, Giobertite, Magnesianite, Roubschite
+    Mg(CO3) = CO3-2 + Mg+2
+    # Editor: Freyer
+    log_k     -8.2843273355294
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      1.30368261650453E+2   0      -4.9344200039177E+3      -4.9345601058392E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+Massicot
+    # Synonyms: Yellow Lead oxide, Chrysitin
+    PbO + 2 H+ = H2O + Pb+2
+    # Description: Applicability for calculations for high-saline solutions to be determined
+    # Original equation: PbO_yellow(s) + H2O(l) = Pb2+ + 2OH-
+    # Editor: Moog
+    log_k     13.07
+    # Evaluation data class: 1, data quality: 2
+    # Reference: MOO2022
+    -analytical_expression      1.35878810535947E+0   0      3.49169313961599E+3   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+
+Mercallite
+    K(HSO4) = H+ + K+ + SO4-2
+    # Editor: Freyer
+    log_k     -1.3637346605614
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      8.11139183383376E+2   0     -4.25454807254582E+4      -2.8480921041554E+2      1.97586360498448E+6      1.42978132124226E-4 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 348.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+Meta-ettringite_13H2O
+    Ca6Al2(SO4)3(OH)12:7H2O + 4 H+ = 2 Al(OH)4- + 6 Ca+2 + 11 H2O + 3 SO4-2
+    # Description: Original reaction from LOT/KUL2019, Table B2, ettringite13. Thermodynamic data from dehydration experiments in water unsaturated conditions.
+    # Original equation: Ca6Al2(SO4)3(OH)12:7H2O(cr) + 4H<+> = 2AlO2<-> + 6Ca<2+> + 3SO4<2-> + 15H2O(l)
+    # Editor: Miron
+    log_k     38.985
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: BAQ/MAT2016
+    # Description: Thermodynamic data from dehydration experiments in water unsaturated conditions. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      4.11783353132771E+2   0      9.91290306250101E+3     -1.64096621448528E+2   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 410.6 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: BAQ/MAT2016
+
+Meta-ettringite_9H2O
+    Ca6Al2(SO4)3(OH)12:3H2O + 4 H+ = 2 Al(OH)4- + 6 Ca+2 + 7 H2O + 3 SO4-2
+    # Description: Original reaction from LOT/KUL2019, Table B2, ettringite9. Thermodynamic data from dehydration experiments in water unsaturated conditions.
+    # Original equation: Ca6Al2(SO4)3(OH)12:3H2O(cr) + 4H<+> = 2AlO2<-> + 6Ca<2+> + 3SO4<2-> + 11H2O(l)
+    # Editor: Miron
+    log_k     47.992
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: BAQ/MAT2016
+    # Description: Thermodynamic data from dehydration experiments in water unsaturated conditions. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression       5.1519500252853E+2   0     -5.70665787318449E+3     -1.81076816312687E+2   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 361 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: BAQ/MAT2016
+
+Metaschoepite
+    UO3:2H2O + 2 H+ = 3 H2O + UO2+2
+    # Editor: Richter
+    log_k     5.35
+    # Evaluation data class: 1, data quality: 1
+    # Reference: ALT/YAL2017
+    # Additional reference: ALT/BRE2004
+    # Description: original reaction in [ALT/BRE2004] UO2<2+> + 2OH<-> + H2O(l) = UO3:2H2O(cr) with logK=22.65+-0.13
+
+Mg(OH)Cl-2-1-4
+    # Synonyms: 2-1-4-phase
+    # Description: The solid phase Mg(OH)Cl-2-1-4 appears at T >= 333.15K.
+    Mg3Cl2(OH)4:4H2O + 4 H+ = 2 Cl- + 8 H2O + 3 Mg+2
+    # Description: The solid phase Mg(OH)Cl-2-1-4 appears at T >= 333.15K.
+    # Editor: Freyer
+    log_k     36.976164305858
+    # Notice: value was extrapolated from tp function
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      6.29605556138941E+1     -9.92434320303299E-2      1.07485532462935E+3   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 333.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 145.595631 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: DIN/OES2012
+
+Mg(OH)Cl-3-1-8
+    # Synonyms: 3-1-8-Cl-phase, Korshunovskite
+    # Description: previous name in the former data set: Oxychloride-Mg
+    Mg4Cl2(OH)6:8H2O + 6 H+ = 2 Cl- + 14 H2O + 4 Mg+2
+    # Original equation: 2Mg<2+> + Cl<-> + 7H2O(l) -> Mg2Cl(OH)3:4H2O(cr) + 3H<+>
+    # Editor: Freyer
+    log_k     52.101854610315
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      9.11196206277583E+0     -2.60639211581897E-2       1.5134366301796E+4   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 373.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 222.737785 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: DEW/WAL1953
+
+Mg(OH)Cl-5-1-8
+    # Synonyms: 5-1-8-phase
+    Mg6Cl2(OH)10:8H2O + 10 H+ = 2 Cl- + 18 H2O + 6 Mg+2
+    # Original equation: 3Mg<2+> + Cl<-> + 9 H2O -> Mg3Cl(OH)5:4H2O + 5H<+>
+    # Editor: Freyer
+    log_k     86.615500432885
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression   0   0      2.58244425135529E+4   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 277.974681 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: SUG/DIN2007a
+
+Mg(OH)Cl-9-1-4
+    # Synonyms: 9-1-4-phase
+    Mg10Cl2(OH)18:4H2O + 18 H+ = 2 Cl- + 22 H2O + 10 Mg+2
+    # Description: The solid phase Mg(OH)Cl-9-1-4 appears at T>353K.
+    # Editor: Freyer
+    log_k     158.23289231361
+    # Notice: value was extrapolated from tp function
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression     -5.01440498679562E+1   0      6.21276420522332E+4   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 373.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 332.764058 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: DIN/FRE2010
+
+Mg(SeO3):6H2O(cr)
+    Mg(SeO3):6H2O = 6 H2O + Mg+2 + SeO3-2
+    # Editor: Bok
+    log_k     -5.9
+    # Evaluation data class: 1, data quality: 2
+    # Reference: HAG/MOO2012
+    # Additional reference: BOK2021
+
+Mg(SeO4):4.5H2O(cr)
+    # Description: high temperature phase of magnesium selenate hydrate
+    Mg(SeO4):4.5H2O = 4.5 H2O + Mg+2 + SeO4-2
+    # Editor: Bok
+    log_k     -0.57314
+    # Notice: value was extrapolated from tp function
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression                2.8854E+0                 -1.16E-2   0   0   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 366.15 K - 373.15 K.
+    # Reference: BOK2021
+
+Mg(SeO4):6H2O(cr)
+    Mg(SeO4):6H2O = 6 H2O + Mg+2 + SeO4-2
+    # Original equation: MgSeO4:6H2O(cr) <=> Mg<2+> + SeO4<2-> + 6 H2O(l)
+    # Editor: Bok
+    log_k     -1.14963541273
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -analytical_expression               1.04189E-1              -2.94098E-3   0   0   0              -4.24071E-6 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 281.15 K - 363.15 K.
+    # Reference: BOK2021
+
+Mg(SeO4):7H2O(cr)
+    Mg(SeO4):7H2O = 7 H2O + Mg+2 + SeO4-2
+    # Editor: Bok
+    log_k     -0.52001999999998
+    # Notice: value was extrapolated from tp function
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression               -8.6297E+0                  2.72E-2   0   0   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 281.15 K.
+    # Reference: BOK2021
+
+Mg3Na4(SeO4)5:18H2O(cr)
+    Mg3Na4(SeO4)5:18H2O = 18 H2O + 3 Mg+2 + 4 Na+ + 5 SeO4-2
+    # Original equation: Na4Mg3(SeO4)5:18H2O(cr) <=> 4 Na<+> + 3 Mg<2+> + 5 SeO4<2-> + 18 H2O(l)
+    # Editor: Bok
+    log_k     -3.94
+    # Evaluation data class: 1, data quality: 2
+    # Reference: HAG/MOO2012
+
+MgAl-OH-LDH_M4AH10
+    Mg4Al2(OH)14:3H2O + 6 H+ = 2 Al(OH)4- + 9 H2O + 4 Mg+2
+    # Description: Original reaction from LOT/KUL2019, Table B2, M4A-OH-LDH Tentative data, recommended for alkali activated materials
+    # Original equation: Mg4Al2(OH)14:3H2O_ss(cr) + 6H<+> = 2AlO2<-> + 4Mg<2+> + 13H2O(l)
+    # Editor: Miron
+    log_k     34.307
+    # Evaluation data class: 1, data quality: 3
+    # Reference: LOT/KUL2019
+    # Additional reference: MYE/LOT2015
+    # Description: Tentative data. recommended for alkali activated materials. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression     -6.47571591185622E+1   0      1.64577757784999E+4      1.77270819326695E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 219.1 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: MYE/LOT2015
+
+MgAl-OH-LDH_M6AH12
+    Mg6Al2(OH)18:3H2O + 10 H+ = 2 Al(OH)4- + 13 H2O + 6 Mg+2
+    # Description: Original reaction from LOT/KUL2019, Table B2, M6A-OH-LDH Tentative data, recommended for alkali activated materials
+    # Original equation: Mg6Al2(OH)18:3H2O(cr) + 10H<+> = 2AlO2<-> + 6Mg<2+> + 17H2O(l)
+    # Editor: Miron
+    log_k     67.989
+    # Evaluation data class: 1, data quality: 3
+    # Reference: LOT/KUL2019
+    # Additional reference: MYE/LOT2015
+    # Description: Tentative data. recommended for alkali activated materials. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression     -1.07049523467572E+2   0      3.00088627466275E+4      3.00627457300552E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 305.4 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: MYE/LOT2015
+
+MgAl-OH-LDH_M8AH14
+    Mg8Al2(OH)22:3H2O + 14 H+ = 2 Al(OH)4- + 17 H2O + 8 Mg+2
+    # Description: Original reaction from LOT/KUL2019, Table B2, M8A-OH-LDH Tentative data, recommended for alkali activated materials
+    # Original equation: Mg8Al2(OH)22:3H2O(cr) + 14H<+> = 2AlO2<-> + 8Mg<2+> + 21H2O(l)
+    # Editor: Miron
+    log_k     101.671
+    # Evaluation data class: 1, data quality: 3
+    # Reference: LOT/KUL2019
+    # Additional reference: MYE/LOT2015
+    # Description: Tentative data. recommended for alkali activated materials. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression     -1.49690149367831E+2   0      4.35751418732234E+4      4.25185609254183E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 392.4 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: MYE/LOT2015
+
+Mirabilite
+    # Synonyms: Glauber Salt
+    Na2(SO4):10H2O = 10 H2O + 2 Na+ + SO4-2
+    # Editor: Freyer
+    log_k     -1.2277342550337
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression     -2.81246224089113E+1      1.32944335421171E-1   0   0   0     -1.43322926417243E-4 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 303.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 230.13924182857 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: ROS/KOC1968
+
+Misenite
+    K8(HSO4)6(SO4) = 6 H+ + 8 K+ + 7 SO4-2
+    # Editor: Freyer
+    log_k     -10.634103135258
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression   0     -5.13828831696351E-2     -1.06081719752633E+3   0   0      9.27367714594951E-5 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 323.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+Monocarboaluminate
+    # Synonyms: Monocarbonat
+    Ca4Al2(CO3)(OH)12:5H2O + 4 H+ = 2 Al(OH)4- + CO3-2 + 4 Ca+2 + 9 H2O
+    # Description: Original reaction from LOT/KUL2019, Table B2, monocarbonate.
+    # Original equation: Ca4Al2CO9:11H2O(s) + 4H<+> = 2AlO2<-> + CO3<2-> + 4Ca<2+> + 13H2O(l)
+    # Editor: Miron
+    log_k     24.539
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: LOT/MAT2008
+    # Description: Additional reference: MAT/LOT2007. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      1.40010366988157E+2   0      2.19945972100366E+3     -4.96470627854198E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+    -Vm 262 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: LOT/MAT2008
+
+Monocarboaluminate_9H2O
+    Ca4Al2CO9:9H2O + 4 H+ = 2 Al(OH)4- + CO3-2 + 4 Ca+2 + 7 H2O
+    # Description: Original reaction from LOT/KUL2019, Table B2, monocarbonate9. Thermodynamic data from hydration-dehydration experiments.
+    # Original equation: Ca4Al2CO9:9H2O(cr) + 4H<+> = 2AlO2<-> + CO3<2-> + 4Ca<2+> + 11H2O(l)
+    # Editor: Miron
+    log_k     28.537
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: BAQ/MAT2015
+    # Description: Additional reference: BAQ/MAT2014. Thermodynamic data from hydration-dehydration experiments. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      1.58243820216793E+2   0      4.21751855060248E+3     -5.81354764141242E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 233.6 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: BAQ/MAT2015
+
+Monohydrocalcite
+    Ca(CO3):H2O = CO3-2 + Ca+2 + H2O
+    # Editor: Freyer
+    log_k     -7.5977872211572
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression     -8.66823475384069E+0   0      3.19151207393957E+2    -2.44512598472548E-11   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 323.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+Monosulfoaluminate
+    # Synonyms: Monosulfat
+    Ca4Al2(SO4)(OH)12:6H2O + 4 H+ = 2 Al(OH)4- + 4 Ca+2 + 10 H2O + SO4-2
+    # Description: Original reaction from LOT/KUL2019, Table B2, monosulphate12. Thermodynamic data from hydration-dehydration experiments.
+    # Original equation: Ca4Al2SO10:12H2O(s) + 4H<+> = 2AlO2<-> + 4Ca<2+> + SO4<2-> + 14H2O(l)
+    # Editor: Miron
+    log_k     26.789
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: BAQ/MAT2015
+    # Description: Additional reference: BAQ/MAT2014. Thermodynamic data from hydration-dehydration experiments. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      1.29176410825662E+2   0      3.29885562384086E+3     -4.58496050879727E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+    -Vm 310.1 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: BAQ/MAT2014
+
+Monosulfoaluminate_10.5H2O
+    Ca4Al2SO10:10.5H2O + 4 H+ = 2 Al(OH)4- + 4 Ca+2 + 8.5 H2O + SO4-2
+    # Description: Original reaction from LOT/KUL2019, Table B2, monosulphate10.5. Thermodynamic data from hydration-dehydration experiments.
+    # Original equation: Ca4Al2SO10:10.5H2O(cr) + 4H<+> = 2AlO2<-> + 4Ca<2+> + SO4<2-> + 12.5H2O(l)
+    # Editor: Miron
+    log_k     28.134
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: BAQ/MAT2015
+    # Description: Additional reference: BAQ/MAT2014. Thermodynamic data from hydration-dehydration experiments. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      1.45904173502511E+2   0      3.40998937443193E+3     -5.22169075507756E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 281.6 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: BAQ/MAT2014
+
+Monosulfoaluminate_14H2O
+    Ca4Al2SO10:14H2O + 4 H+ = 2 Al(OH)4- + 4 Ca+2 + 12 H2O + SO4-2
+    # Description: Original reaction from LOT/KUL2019, Table B2, monosulphate14. Thermodynamic data from hydration-dehydration experiments.
+    # Original equation: Ca4Al2SO10:14H2O(cr) + 4H<+> = 2AlO2<-> + 4Ca<2+> + SO4<2-> + 16H2O(l)
+    # Editor: Miron
+    log_k     26.764
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: BAQ/MAT2015
+    # Description: Additional reference: BAQ/MAT2014. Thermodynamic data from hydration-dehydration experiments. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      1.02943620376404E+2   0      4.84912531172412E+3     -3.73595076558932E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 331.6 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: BAQ/MAT2014
+
+Monosulfoaluminate_16H2O
+    Ca4Al2SO10:16H2O + 4 H+ = 2 Al(OH)4- + 4 Ca+2 + 14 H2O + SO4-2
+    # Description: Original reaction from LOT/KUL2019, Table B2, monosulphate16. Thermodynamic data from hydration-dehydration experiments.
+    # Original equation: Ca4Al2SO10:16H2O(cr) + 4H<+> = 2AlO2<-> + 4Ca<2+> + SO4<2-> + 18H2O(l)
+    # Editor: Miron
+    log_k     26.85
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: BAQ/MAT2015
+    # Description: Additional reference: BAQ/MAT2014. Thermodynamic data from hydration-dehydration experiments. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      8.69706020592215E+1   0      3.92099773304992E+3      -2.9611486425538E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 350.5 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: BAQ/MAT2014
+
+Monosulfoaluminate_9H2O
+    Ca4Al2SO10:9H2O + 4 H+ = 2 Al(OH)4- + 4 Ca+2 + 7 H2O + SO4-2
+    # Description: Original reaction from LOT/KUL2019, Table B2, monosulphate9. Thermodynamic data from hydration-dehydration experiments.
+    # Original equation: Ca4Al2SO10:9H2O(cr) + 4H<+> = 2AlO2<-> + 4Ca<2+> + SO4<2-> + 11H2O(l)
+    # Editor: Miron
+    log_k     30.153
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: BAQ/MAT2015
+    # Description: Additional reference: BAQ/MAT2014. Thermodynamic data from hydration-dehydration experiments. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      1.59852705296428E+2   0      4.55078303725583E+3     -5.85843302852483E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 274.6 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: BAQ/MAT2014
+
+MSH_M075SH
+    Mg1.5Si2O5.5(H2O)2.5 + 3 H+ = 1.5 Mg+2 + 2 Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table 2, M1.5S2H2.5, with LOGK298 = -28.80
+    # Original equation: Mg1.5Si2O5.5(H2O)2.5(s) = 1.5Mg<2+> + 2SiO2(aq) + 3OH<-> + H2O(l)
+    # Editor: Miron
+    log_k     13.2
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: NIE/ENE2016
+    # Description: Calculated from LOGK298 = -28.80 for Mg1.5Si2O5.5(H2O)2.5(s) = 1.5Mg<2+> + 2SiO2(aq) + 3OH<-> + H2O(l) and from the stability constant of H2O(l)
+    -Vm 95 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: NIE/ENE2016
+
+MSH_M15SH
+    Mg1.5SiO3.5(H2O)2.5 + 3 H+ = 2 H2O + 1.5 Mg+2 + Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table 2, M1.5SH2.5, with LOGK298 = -23.57
+    # Original equation: Mg1.5SiO3.5(H2O)2.5(s) = 1.5Mg<2+> + SiO2(aq) + 3OH<-> + H2O(l)
+    # Editor: Miron
+    log_k     18.43
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: NIE/ENE2016
+    # Description: Calculated from LOGK298 = -23.57 for Mg1.5SiO3.5(H2O)2.5(s) = 1.5Mg<2+> + SiO2(aq) + 3OH<-> + H2O(l) and from the stability constant of H2O(l)
+    -Vm 74 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: NIE/ENE2016
+
+Na(H2PO4):2H2O(cr)
+    Na(H2PO4):2H2O = 2 H2O + 2 H+ + Na+ + PO4-3
+    # Editor: Moog
+    log_k     -19.16
+    # Evaluation data class: 1, data quality: 1
+    # Reference: SCH/MUN2013a
+
+Na(HSO4):H2O(cr)
+    # Synonyms: Matteuccite, Sodium bisulfate
+    Na(HSO4):H2O = H2O + H+ + Na+ + SO4-2
+    # Editor: Freyer
+    log_k     -0.15979473982426
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression     -2.08493918150248E+3     -3.20028818264769E+0     -2.45313353085055E+2      1.13611974129533E+3     -9.36890347546486E+0      2.57065091927689E-3 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 333.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+Na-Autunite
+    Na(UO2PO4):3H2O = 3 H2O + Na+ + PO4-3 + UO2+2
+    # Editor: Bok
+    log_k     -24.3
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GRE/GAO2020
+
+Na-Boltwoodite
+    Na(UO2(SiO3OH)):H2O + 3 H+ = H2O + Na+ + Si(OH)4 + UO2+2
+    # Editor: Richter
+    log_k     5.81
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GRE/GAO2020
+
+Na-Compreignacite
+    Na2(UO2)6O4(OH)6:7H2O + 14 H+ = 17 H2O + 2 Na+ + 6 UO2+2
+    # Editor: Richter
+    log_k     39.4
+    # Evaluation data class: 1, data quality: 2
+    # Reference: GOR/FEI2008
+    # Description: [GOR/FEI2008]: specification of uncertainty 1.10 (positive) and 0.70 (negative) for 1 sigma; here: 2sigma
+
+Na-Weeksite
+    Na2((UO2)2(Si2O5)3):4H2O + 5 H2O + 6 H+ = 2 Na+ + 6 Si(OH)4 + 2 UO2+2
+    # Editor: Richter
+    log_k     1.5
+    # Evaluation data class: 1, data quality: 2
+    # Reference: GUI/FAN2003
+    # Additional reference: NGU/SIL1992
+    # Description: [GUI/FAN2003]: not selected as recommended but as guidance value for scoping calculations
+
+Na2(CO3):7H2O(cr)
+    Na2(CO3):7H2O = CO3-2 + 7 H2O + 2 Na+
+    # Editor: Freyer
+    log_k     -0.49457099560022
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      2.10591298545124E+2       4.9435235606449E-2     -8.22303554244188E+3     -8.01171999312045E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 313.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 153.70556196026 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: GRO1908
+
+Na2(HPO4):12H2O(cr)
+    Na2(HPO4):12H2O = 12 H2O + H+ + 2 Na+ + PO4-3
+    # Editor: Moog
+    log_k     -14.17
+    # Evaluation data class: 1, data quality: 1
+    # Reference: SCH/MUN2013a
+
+Na2(HPO4):7H2O(cr)
+    Na2(HPO4):7H2O = 7 H2O + H+ + 2 Na+ + PO4-3
+    # Description: logK for original reaction: 1.406
+    # Original equation: 2Na<+> + HPO4<2-> + 7H2O = Na2(HPO4):7H2O
+    # Editor: Bok
+    log_k     -13.756
+    # Evaluation data class: 1, data quality: 1
+    # Reference: SCH/MUN2015
+    # Description: Original equation: 2Na<+> + HPO4<2-> + 7H2O = Na2HPO4:7H2O(cr) log K = 1.406
+
+Na2(SeO3)(cr)
+    Na2(SeO3) = 2 Na+ + SeO3-2
+    # Original equation: Na2SeO3(cr) <=> 2 Na<+> + SeO3<2->
+    # Editor: Bok
+    log_k     2.0152868304577
+    # Notice: value was extrapolated from tp function
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -analytical_expression               1.44551E+1               -6.3691E-2   0   0   0               7.36799E-5 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 313.15 K - 373.15 K.
+    # Reference: BOK2021
+
+Na2(SeO3):5H2O(cr)
+    Na2(SeO3):5H2O = 5 H2O + 2 Na+ + SeO3-2
+    # Editor: Bok
+    log_k     0.7505586978123
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+    # Additional reference: BOK2021
+    -analytical_expression              -7.41455E+2              -1.23387E+0   0      4.09667999971583E+2   0                1.0843E-3 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 313.15 K.
+    # Reference: BOK2021
+
+Na2(SeO4)(cr)
+    Na2(SeO4) = 2 Na+ + SeO4-2
+    # Original equation: Na2SeO4(cr) <=> 2 Na<+> + SeO4<2->
+    # Editor: Bok
+    log_k     0.806756792022
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -analytical_expression               2.84759E+0              -1.01888E-2   0   0   0               1.12152E-5 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 293.15 K - 373.15 K.
+    # Reference: BOK2021
+
+Na2(SeO4):10H2O(cr)
+    Na2(SeO4):10H2O = 10 H2O + 2 Na+ + SeO4-2
+    # Original equation: Na2SeO4:10H2O(cr) <=> 2 Na<+> + SeO4<2-> + 10 H2O(l)
+    # Editor: Bok
+    log_k     -0.59945576052309
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -analytical_expression               1.43231E+1   0              -4.44916E+3   0   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 303.15 K.
+    # Reference: BOK2021
+
+Na2(SeO4):7.5H2O(cr)
+    # Description: metastable sodium selenate hydrate
+    Na2(SeO4):7.5H2O = 7.5 H2O + 2 Na+ + SeO4-2
+    # Description: metastable phase below T = 20 C
+    # Editor: Bok
+    log_k     0.047894851584773
+    # Notice: value was extrapolated from tp function
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression                 6.719E+0   0              -1.98899E+3   0   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 293.15 K.
+    # Reference: BOK2021
+
+Na2Ca5(SO4)6:3H2O(cr)
+    # Synonyms: Omongwaite
+    Ca5Na2(SO4)6:3H2O = 5 Ca+2 + 3 H2O + 2 Na+ + 6 SO4-2
+    # Editor: Freyer
+    log_k     -22.721616013278
+    # Notice: value was extrapolated from tp function
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression       5.4666362911343E+2   0     -2.36683685856106E+4     -1.98025493549823E+2   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 308.15 K - 348.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+Na3(HSO4)(SO4)(cr)
+    # Synonyms: Ivsite
+    Na3(HSO4)(SO4) = H+ + 3 Na+ + 2 SO4-2
+    # Editor: Freyer
+    log_k     -0.63446529669107
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression     -1.15199402833647E+4     -6.07762745858731E+0      2.46146805172918E+5      4.95575057550063E+3   0      2.73460347695005E-3 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+Na3(PO4):12H2O(cr)
+    Na3(PO4):12H2O = 12 H2O + 3 Na+ + PO4-3
+    # Editor: Moog
+    log_k     -3.313
+    # Evaluation data class: 1, data quality: 3
+    # Reference: SCH/MUN2013a
+
+Na3[NpO2(CO3)2](cr)
+    Na3(NpO2(CO3)2) = 2 CO3-2 + 3 Na+ + NpO2+
+    # Editor: Miron
+    log_k     -14.22
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Editor: Marquardt
+
+NaAm(CO3)2:5H2O(cr)
+    NaAm(CO3)2:5H2O = Am+3 + 2 CO3-2 + 5 H2O + Na+
+    # Editor: Marquardt
+    log_k     -21.0
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+NaCm(CO3)2:5H2O(cr)
+    NaCm(CO3)2:5H2O = 2 CO3-2 + Cm+3 + 5 H2O + Na+
+    # Editor: Marquardt
+    log_k     -21.0
+    # Evaluation data class: 2, data quality: 2
+    # Reference: GUI/FAN2003
+
+Nahcolite
+    # Synonyms: Sodium bicarbonate, Thermokalite
+    Na(HCO3) = CO3-2 + H+ + Na+
+    # Editor: Freyer
+    log_k     -10.750004516034
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      3.35313808826634E+2      1.26999160022526E-1     -1.15862467224774E+4     -1.37173411301448E+2   0     -6.34634867854451E-5 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 37.823777253489 cm3/mol
+    # Reference: NotYetDetermined
+
+Namuwite
+    Zn4(OH)6(SO4):4H2O + 6 H+ = 10 H2O + SO4-2 + 4 Zn+2
+    # Original equation: 3Zn(OH)2:ZnSO4:4H2O = 4Zn2+ + SO42- + 6OH- + 4H2O
+    # Editor: Moog
+    log_k     28.01
+    # Evaluation data class: 1, data quality: 3
+    # Reference: HAG2022
+
+NaNO3(cr)
+    # Synonyms: Nitratine
+    NaNO3 = NO3- + Na+
+    # Editor: Moog
+    log_k     1.066
+    # Evaluation data class: 1, data quality: 1
+    # Reference: MUN2024
+
+NaNpO2(CO3):3.5H2O(cr)
+    NaNpO2(CO3):3.5H2O = CO3-2 + 3.5 H2O + Na+ + NpO2+
+    # Editor: Marquardt
+    log_k     -11.0
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+Natrite
+    Na2(CO3) = CO3-2 + 2 Na+
+    # Editor: Freyer
+    log_k     0.97911264717613
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      1.26797828228678E+3      5.60599247345915E-1     -3.07549624072919E+4     -5.29084334596188E+2   0     -2.45287977270752E-4 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+Natron
+    # Synonyms: Sodium carbonate decahydrate
+    Na2(CO3):10H2O = CO3-2 + 10 H2O + 2 Na+
+    # Editor: Freyer
+    log_k     -0.86133243023772
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      5.05951329120489E+2      1.45341222707639E-1     -1.64188004880651E+4     -2.00076889770882E+2   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 313.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+Nd(OH)3(am)
+    Nd(OH)3 + 3 H+ = 3 H2O + Nd+3
+    # Editor: Marquardt
+    log_k     17.2
+    # Evaluation data class: 1, data quality: 1
+    # Reference: NEC/ALT2009
+
+Nesquehonite
+    Mg(CO3):3H2O = CO3-2 + 3 H2O + Mg+2
+    # Editor: Freyer
+    log_k     -5.2883516015972
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      1.13004839715967E+2   0     -4.31677589300768E+3     -4.19548980696374E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 278.15 K - 333.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 75.606415 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: GIE/LEN2000
+
+Nestolaite
+    # Synonyms: 
+    Ca(SeO3):H2O = Ca+2 + H2O + SeO3-2
+    # Editor: Bok
+    log_k     -6.61
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -analytical_expression            -5.4144185E+0                 -4.01E-3   0   0   0   0 
+    # Evaluation data class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 333.15 K.
+    # Reference: BIS/HAG2016
+    # Description: Original solubility product data: LogK(T) = -6.61-0.0040(T-298.15K)
+
+Ningyoite
+    Ca(U(PO4)2):2H2O = Ca+2 + 2 H2O + 2 PO4-3 + U+4
+    # Original equation: Ca<2+>+U<4+>+2H3PO4<0>+2H2O(l) = CaU(PO4)2:2H2O(cr)+6H<+>
+    # Editor: Richter
+    log_k     -55.92
+    # Evaluation data class: 1, data quality: 3
+    # Reference: MUT1965
+    # Description: original reaction Ca<2+> + U<4+> + 2H3PO4<0> + 2H2O = CaU(PO4)2:2H2O(cr)+6H<+>, mean of 4 log K (12.97,13.59,11.57,11.96)=12.52; S=36cal/mol K questionable (revised by [LAN1978] 70 cal/mol K)
+
+Np(OH)4(am)
+    Np(OH)4 + 4 H+ = 4 H2O + Np+4
+    # Original equation: Np<4+> + 4OH<-> --> 2H2O(l) + NpO2(am,hyd); logK=56.7
+    # Editor: Marquardt
+    log_k     -0.7
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: Original reaction: Np<4+> + 4OH<-> --> 2H2O(l) + NpO2(am,hyd); logK=56.7
+
+NpO2(OH)_fresh(am)
+    NpO2(OH) + H+ = H2O + NpO2+
+    # Editor: Marquardt
+    log_k     5.3
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+NpO2.5_hyd(s)
+    NpO2.5 + H+ = 0.5 H2O + NpO2+
+    # Description: The species is equivalent with Np2O5(s)! Use this species with care, because it will be not in equilibrium in certain aquatic systems!
+    # Editor: Marquardt
+    log_k     3.3
+    # Evaluation data class: 1, data quality: 3
+    # Reference: ALT/BRE2004
+    # Description: The species is equivalent with Np2O5(s)! Use this species with care, because it will be not in equilibrium in several aquatic systems!
+
+Otavite
+    Cd(CO3) = CO3-2 + Cd+2
+    # Original equation: Cd<2+>+HCO3<->=CdCO3+H<+>
+    # Editor: Moog
+    log_k     -12.1
+    # Evaluation data class: -1, data quality: 1
+    # Reference: HAG2024
+    # Description: Original LOGK298 for dissolution reaction = -1.8
+
+Palmierite
+    (K2SO4)(PbSO4) = 2 K+ + Pb+2 + 2 SO4-2
+    # Editor: Moog
+    log_k     -12.8
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG2022
+
+Parsonsite
+    Pb2UO2(PO4)2 = 2 PO4-3 + 2 Pb+2 + UO2+2
+    # Editor: Bok
+    log_k     -50.61
+    # Evaluation data class: 4, data quality: 1
+    # Reference: VOC/VAN1991
+
+Phosgenite
+    # Synonyms: Corneous Lead, Cromfordite, Galenoceratite, Horn lead, Lead Chlorocarbonate
+    (PbCl2)(PbCO3) = CO3-2 + 2 Cl- + 2 Pb+2
+    # Editor: Moog
+    log_k     -20.64
+    # Evaluation data class: 1, data quality: 2
+    # Reference: MOO2022
+    # Description: Determined from equilibrium with Cerussite [NAS/MER1962, NAS/MER1963]
+
+Pickeringite
+    # Synonyms: Magnesia Alum, Magnesium-Halotrichite, Picralluminite, Pikroalumogen, Sonomaite
+    MgAl2(SO4)4:22H2O = 2 Al(OH)4- + 14 H2O + 8 H+ + Mg+2 + 4 SO4-2
+    # Editor: Miron
+    log_k     -54.9703
+    # Evaluation data class: 1, data quality: 1
+    # Reference: MIR2023
+
+Picromerite
+    # Synonyms: Schoenite
+    K2Mg(SO4)2:6H2O = 6 H2O + 2 K+ + Mg+2 + 2 SO4-2
+    # Editor: Freyer
+    log_k     -4.3344193068672
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      9.19556133476381E-1   0     -1.56647433181964E+3   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 323.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 198.383488 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: BOS/BEL2009
+
+Pirssonite
+    # Synonyms: Pirsonnite
+    CaNa2(CO3)2:2H2O = 2 CO3-2 + Ca+2 + 2 H2O + 2 Na+
+    # Editor: Freyer
+    log_k     -9.0696809324492
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      3.32671941396731E+2   0      -1.5683368467696E+4     -1.16850662275949E+2   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 373.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 103.0676451937 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: GRO1908
+
+Plumbonacrite
+    (PbCO3)3(PbO)2:H2O + 4 H+ = 3 CO3-2 + 3 H2O + 5 Pb+2
+    # Description: Sum formula consistent with a recent investigation into the crystal structure of Plumbonacrite [KRI/BUR2000]
+    # Editor: Moog
+    log_k     -22.2
+    # Evaluation data class: 1, data quality: 3
+    # Reference: MOO2022
+
+Polyhalite
+    # Synonyms: Ischelite, Polygalite, Polyhallite
+    K2MgCa2(SO4)4:2H2O = 2 Ca+2 + 2 H2O + 2 K+ + Mg+2 + 4 SO4-2
+    # Editor: Freyer
+    log_k     -14.131541045168
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      -3.5688476438812E+1      1.56862650138163E-1   0   0   0     -2.83616942989345E-4 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 218.218806 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: BIN2005
+
+Portlandite
+    # Synonyms: Portlandit
+    Ca(OH)2 + 2 H+ = Ca+2 + 2 H2O
+    # Editor: Freyer
+    log_k     22.870310513818
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      3.75101047635346E+2      2.50906886538057E-1   0     -1.67720768150292E+2   0     -1.35268615040491E-4 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 32.784372 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: DES/GRE1993
+
+Pu(OH)4(am)
+    Pu(OH)4 + 4 H+ = 4 H2O + Pu+4
+    # Original equation: 4OH<-> + Pu<4+> --> 2H2O(l) + PuO2(am,hyd); logK=58.33 (GUI/FAN2003)
+    # Editor: Marquardt
+    log_k     -2.33
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: Original reaction: 4OH<-> + Pu<4+> --> 2H2O(l) + PuO2(am,hyd); logK=58.33 (GUI/FAN2003)
+
+Qatranaite
+    CaZn2(OH)6:2H2O + 6 H+ = Ca+2 + 8 H2O + 2 Zn+2
+    # Original equation: Ca(OH)2:2Zn(OH)2:2H2O = 2Zn2+ + Ca2+ + 6OH- + 2H2O
+    # Editor: Moog
+    log_k     43.94
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG2022
+
+Rutherfordine
+    # Synonyms: Diderichite
+    UO2(CO3) = CO3-2 + UO2+2
+    # Editor: Richter
+    log_k     -14.76
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+Saleeite
+    # Synonyms: Saléeite
+    Mg((UO2)2(PO4)2):8H2O = 8 H2O + Mg+2 + 2 PO4-3 + 2 UO2+2
+    # Editor: Richter
+    log_k     -49.2
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GRE/GAO2020
+
+Sepiolite
+    # Synonyms: Parasepiolite
+    # Description: Crystalline MSH phase used by REA1992. Relevance in Mg-bearing cementitious systems not yet clear.
+    Mg2Si3O7.5(OH):3H2O + 0.5 H2O + 4 H+ = 2 Mg+2 + 3 Si(OH)4
+    # Editor: Miron
+    log_k     15.91
+    # Evaluation data class: 1, data quality: 1
+    # Reference: ALT/BRE2011
+
+Simonkolleite
+    Zn5Cl2(OH)8:H2O + 8 H+ = 2 Cl- + 9 H2O + 5 Zn+2
+    # Original equation: 4Zn(OH)2:ZnCl2:H2O = 5Zn2+ + 2 Cl- + 8OH- + H2O
+    # Editor: Moog
+    log_k     38.21
+    # Evaluation data class: 1, data quality: 3
+    # Reference: HAG2022
+
+SiO2:2H2O(am)
+    # Synonyms: amorphous silica, hydrated
+    SiO2:2H2O = Si(OH)4
+    # Editor: Miron
+    log_k     -2.7135214012358
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression                -8.476E+0   0               -4.8524E+2      3.06801042960713E+0   0                -2.268E-6 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 623.15 K.
+    # Reference: GUN/ARN2000
+
+SiO2_alpha_Qtz(cr)
+    # Synonyms: Alpha-Quartz
+    SiO2 + 2 H2O = Si(OH)4
+    # Editor: Miron
+    log_k     -3.7463434956186
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -analytical_expression               -3.4188E+1   0                1.9747E+2       1.2245000000218E+1   0                -5.851E-6 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 573.15 K.
+    # Reference: GUN/ARN2000
+
+Sklodowskite
+    # Synonyms: Chinkolobwite
+    Mg((UO2)2(SiO3OH)2):6H2O + 6 H+ = 6 H2O + Mg+2 + 2 Si(OH)4 + 2 UO2+2
+    # Editor: Richter
+    log_k     14.48
+    # Evaluation data class: 3, data quality: 3
+    # Reference: HEM1982
+    # Description: ATTENTION: [HEM1982] estimated DFG298=-6319+-25kJ/mol; no logK from solubility experiments are available, the here entered logK is calculated from DFG!, otherwise the mineral is relevant, and so the logK should be used with reservation
+
+Smithsonite
+    # Synonyms: Bonamite, Zinc Spar
+    ZnCO3 = CO3-2 + Zn+2
+    # Original equation: ZnCO3(s) = Zn2+ + CO32
+    # Editor: Moog
+    log_k     -10.92
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HAG2022
+
+SO4-CO3-AFt_ettringite03
+    (SO4)Ca2Al0.66666666667(OH)4:8.66666666667H2O + 1.33333333332 H+ = 0.66666666667 Al(OH)4- + 2 Ca+2 + 10 H2O + SO4-2
+    # Description: Original reaction from LOT/KUL2019, Table B2, ettringite03_ss. Small differences between the composition of this Pcon and that in LOT/KUL2019 are due to a small charge imbalance in the latter which had to be corrected for THEREDA.
+    # Original equation: (SO4)Ca2Al0.6666667(OH)4:8.6666667H2O(s) + 1.333333H<+> = 0.666667AlO2<-> + 2Ca<2+> + SO4<2-> + 11.333333H2O(l)
+    # Editor: Miron
+    log_k     3.72
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: LOT/MAT2008
+    # Description: Additional reference: MAT/LOT2007. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      8.32713070950411E+1   0     -3.19204820526061E+3     -2.78225656112027E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 235.67 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: LOT/MAT2008
+
+SO4-CO3-AFt_tricarboalu03
+    (CO3)Ca2Al0.66666666667(OH)4:8.66666666667H2O + 1.33333333332 H+ = 0.66666666667 Al(OH)4- + CO3-2 + 2 Ca+2 + 10 H2O
+    # Description: Original reaction from LOT/KUL2019, Table B2, tricarboalu03. Small differences between the composition of this Pcon and that in LOT/KUL2019 are due to a small charge imbalance in the latter which had to be corrected for THEREDA.
+    # Original equation: (CO3)Ca2Al0.6666667(OH)4:8.6666667H2O(s) + 1.333333H<+> = 0.666667AlO2<-> + CO3<2-> + 2Ca<2+> + 11.333333H2O(l)
+    # Editor: Miron
+    log_k     3.174
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: LOT/MAT2008
+    # Description: Additional reference: MAT/LOT2007. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      8.23183382579483E+1   0      -2.5860630692773E+3     -2.84794894708166E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 216.67 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: LOT/MAT2008
+
+SO4-OH-AFm_C4AH13
+    Ca4Al2(OH)14:6H2O + 6 H+ = 2 Al(OH)4- + 4 Ca+2 + 12 H2O
+    # Description: Original reaction from LOT/KUL2019, Table B2, C4AH13
+    # Original equation: Ca4Al2(OH)14:6H2O(cr) + 6H<+> = 2AlO2<-> + 4Ca<2+> + 16H2O(l)
+    # Editor: Miron
+    log_k     58.76
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: BAQ/MAT2015
+    # Description: exact value was used instead of rounded value given in the reference.
+    -analytical_expression      5.53249049783929E+1   0       1.5044874910155E+4     -1.90046076076642E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 274 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: BAQ/MAT2015
+
+SO4-OH-AFm_monosulphate12
+    Ca4Al2SO10:12H2O + 4 H+ = 2 Al(OH)4- + 4 Ca+2 + 10 H2O + SO4-2
+    # Description: Original reaction from LOT/KUL2019, Table B2, monosulphate12
+    # Original equation: Ca4Al2SO10:12H2O(cr) + 4H<+> = 2AlO2<-> + 4Ca<2+> + SO4<2-> + 14H2O(l)
+    # Editor: Miron
+    log_k     26.789
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: BAQ/MAT2015
+    # Description: Additional reference: BAQ/MAT2014. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      1.29176443045239E+2   0      3.29885562384086E+3     -4.58496050879727E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 310 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: BAQ/MAT2015
+
+Soddyite
+    # Synonyms: Soddite
+    (UO2)2(SiO4):2H2O + 4 H+ = 2 H2O + Si(OH)4 + 2 UO2+2
+    # Editor: Richter
+    log_k     5.75
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GRE/GAO2020
+
+SrCl2:6H2O(cr)
+    SrCl2:6H2O = 2 Cl- + 6 H2O + Sr+2
+    # Editor: Moog
+    log_k     1.8066
+    # Evaluation data class: 1, data quality: 1
+    # Reference: SCH2016
+
+Straetlingite-H2O_straetlingite7
+    Ca2Al2SiO7:7H2O + 2 H+ = 2 Al(OH)4- + 2 Ca+2 + 2 H2O + Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, straetlingite7. Thermodynamic data from hydration-dehydration experiments.
+    # Original equation: Ca2Al2SiO7:7H2O(cr) + 2H<+> = 2AlO2<-> + 2Ca<2+> + 8H2O(l) + SiO2(aq)
+    # Editor: Miron
+    log_k     4.814
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: BAQ/MAT2015
+    # Description: Thermodynamic data from hydration-dehydration experiments. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      2.31576022599364E+1   0      1.20225417145141E+3     -9.04286602577903E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 215.5 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: BAQ/MAT2015
+
+Straetlingite-H2O_straetlingite8
+    Ca2Al2SiO7:8H2O + 2 H+ = 2 Al(OH)4- + 2 Ca+2 + 3 H2O + Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, straetlingite
+    # Original equation: Ca2Al2SiO7:8H2O_ss(cr) + 2H<+> = 2AlO2<-> + 2Ca<2+> + 9H2O(l) + SiO2(aq)
+    # Editor: Miron
+    log_k     4.113
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: LOT/MAT2008
+    # Description: Additional reference: MAT/LOT2007. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      1.14025140697908E+1   0      1.36689972558176E+3     -4.79871934726158E+0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 216.1 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: LOT/MAT2008
+
+Straetlingite_5.5H2O
+    Ca2Al2SiO7:5.5H2O + 2 H+ = 2 Al(OH)4- + 2 Ca+2 + 0.5 H2O + Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, straetlingite5.5. Thermodynamic data from hydration-dehydration experiments.
+    # Original equation: Ca2Al2SiO7:5.5H2O(cr) + 2H<+> = 2AlO2<-> + 2Ca<2+> + 6.5H2O(l) + SiO2(aq)
+    # Editor: Miron
+    log_k     7.096
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: BAQ/MAT2015
+    # Description: Thermodynamic data from hydration-dehydration experiments. Exact value was used instead of rounded value given in the reference.
+    -analytical_expression      3.79080283189499E+1   0      2.18148920159887E+3     -1.54090860435552E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP2
+    -Vm 212.8 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: BAQ/MAT2015
+
+Swartzite
+    CaMg(UO2(CO3)3):12H2O = 3 CO3-2 + Ca+2 + 12 H2O + Mg+2 + UO2+2
+    # Original equation: CaMgUO2(CO3)3:12H2O = Ca<2+> + Mg<2+> + UO2<2+> + 3CO3<2-> + 12H2O
+    # Editor: Bok
+    log_k     -37.9
+    # Evaluation data class: 1, data quality: 2
+    # Reference: GOR/BUR2008
+    # Additional reference: ALW/WIL1980
+    # Description: Ksp calculated from reported standard state Gibbs free energy of formation from ALW/WIL1980 by GOR/BUR2008.
+
+Sylvite
+    # Synonyms: Hoevelite, Hövelite, Leopoldite, Potassium Chloride, Silvite, Sylvine
+    KCl = Cl- + K+
+    # Editor: Freyer
+    log_k     0.91484954250802
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      3.04776769685732E+2      1.37903342575679E-1     -8.48914706089572E+3     -1.25476172830597E+2   0     -6.77491243360969E-5 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 473.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 37.500654 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: BAR/WAL1954
+
+Syngenite
+    # Synonyms: Kaluszite
+    CaK2(SO4)2:H2O = Ca+2 + H2O + 2 K+ + 2 SO4-2
+    # Editor: Freyer
+    log_k     -7.36691027619
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression     -1.51158649489555E+5     -8.68232982839149E+1      3.11944634731335E+6      6.57427185639545E+4   0      4.38604225981233E-2 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 127.342024 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: COR/SAB1967
+
+Tachyhydrite
+    CaMg2Cl6:12H2O = Ca+2 + 6 Cl- + 12 H2O + 2 Mg+2
+    # Editor: Freyer
+    log_k     17.556047417457
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression     -1.00226613676532E+3     -1.76259361479276E+0     -2.51177250144365E+1      5.73817024595585E+2   0       1.4123757521892E-3 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 309.37798 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: CLA/EVA1980
+
+Tamarugite
+    NaAl(SO4)2:6H2O = Al(OH)4- + 2 H2O + 4 H+ + Na+ + 2 SO4-2
+    # Editor: Miron
+    log_k     -27.2879
+    # Evaluation data class: 1, data quality: 1
+    # Reference: MIR2023
+
+TcO2:0.6H2O(am)
+    TcO2:0.6H2O + 0.4 H2O = TcO(OH)2
+    # Description: Corresponding equivalent in NEA-TDB: TcO2(am, hyd, aged)
+    # Editor: Kiefer
+    log_k     -8.72
+    # Evaluation data class: 1, data quality: 2
+    # Reference: GRE/GAO2020
+
+Th(OH)4_aged(am)
+    Th(OH)4 + 4 H+ = 4 H2O + Th+4
+    # Original equation: 4OH<-> + Th<4+> --> 2H2O(l) + ThO2(am,hyd,aged); logK=47.5 (RAN/FUG2008)
+    # Editor: Marquardt
+    log_k     8.5
+    # Evaluation data class: 1, data quality: 2
+    # Reference: RAN/FUG2008
+    # Description: Original reaction: 4OH<-> + Th<4+> --> 2H2O(l) + ThO2(am,hyd,aged); logK=47.5 (RAN/FUG2008)
+
+Thaumasite
+    Ca3(SiO3)(SO4)(CO3):15H2O + 2 H+ = CO3-2 + 3 Ca+2 + 14 H2O + SO4-2 + Si(OH)4
+    # Description: Original reaction from LOT/KUL2019, Table B2, thaumasite
+    # Original equation: (CaSiO3)(CaSO4)(CaCO3):15H2O(s) + 2H<+> = CO3<2-> + 3Ca<2+> + SO4<2-> + 16H2O(l) + SiO2(aq)
+    # Editor: Miron
+    log_k     -0.917
+    # Evaluation data class: 1, data quality: 1
+    # Reference: LOT/KUL2019
+    # Additional reference: MAT/GLA2015
+    # Description: exact value was used instead of rounded value given in the reference.
+    -analytical_expression      1.67233928729872E+2   0     -8.54440888602291E+3     -5.63736167254594E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+    -Vm 330 cm3/mol
+    # Reference: LOT/KUL2019
+    # Reference: MAT/GLA2015
+
+Thenardite
+    # Synonyms: Pyrotechnite, Thénardite
+    Na2(SO4) = 2 Na+ + SO4-2
+    # Editor: Freyer
+    log_k     -0.28749915183931
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      9.30739686747024E+1      2.03888557661278E-3     -3.90897855291834E+3     -3.26775969811774E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 473.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 53.3993 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: HAW/FER1975
+
+Thermonatrite
+    Na2(CO3):H2O = CO3-2 + H2O + 2 Na+
+    # Editor: Freyer
+    log_k     0.45829469667429
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      1.23848526018615E+3      6.39312451759057E-1     -2.75625587094656E+4     -5.28794744121715E+2   0     -3.11885543501632E-4 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+Trona
+    # Synonyms: Tronite
+    Na3(CO3)(HCO3):2H2O = 2 CO3-2 + 2 H2O + H+ + 3 Na+
+    # Editor: Freyer
+    log_k     -11.428071315729
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      1.72789868466883E+3      8.56962400794088E-1     -4.30083180726808E+4     -7.32804121950662E+2   0     -4.19642512620795E-4 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 373.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 105.61944291589 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: GRO1908
+
+Trona-K
+    K2Na(CO3)(HCO3):2H2O = 2 CO3-2 + 2 H2O + H+ + 2 K+ + Na+
+    # Editor: Freyer
+    log_k     -9.0987590679387
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+
+U(HPO4)2:4H2O(cr)
+    U(HPO4)2:4H2O = 4 H2O + 2 H+ + 2 PO4-3 + U+4
+    # Original equation: 4H2O + 2H3PO4<0-> + U<4+> = U(HPO4)2:4H2O(cr) + 4H<+>
+    # Editor: Richter
+    log_k     -55.194
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Additional reference: GRE/FUG1992
+    # Description: original equation: 4H2O + 2H3PO4<0-> + U<4+> = U(HPO4)2:4H2O(cr) + 4H<+>; original value 11.79 +-0.1500
+
+U(OH)2(SO4)(cr)
+    U(OH)2(SO4) + 2 H+ = 2 H2O + SO4-2 + U+4
+    # Original equation: 2OH-<> + SO4<2-> + U<4+> = U(OH)2(SO4)(cr)
+    # Editor: Richter
+    log_k     -3.168
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: original equation: 2OH-<> + SO4<2-> + U<4+> = U(OH)2(SO4)(cr); original value 31.170 +-0.500
+
+U(OH)4(am)
+    U(OH)4 + 4 H+ = 4 H2O + U+4
+    # Original equation: U<4+> + 4OH<-> = U(OH)4(am)
+    # Editor: Richter
+    log_k     1.5
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Additional reference: YAN/CEV2023
+    # Description: original reaction: U<4+> + 4OH<-> = UO2(am,hyd)+2H2O, logK=-54.5+-1.0
+
+UO2(SO4):2.5H2O(cr)
+    UO2(SO4):2.5H2O = 2.5 H2O + SO4-2 + UO2+2
+    # Editor: Richter
+    log_k     -1.5889861971706
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    # Additional reference: GRE/FUG1992
+    # Description: remark in [GUI/FAN2003]: internally calculated from DRG
+
+UO2(SO4):3.5H2O(cr)
+    UO2(SO4):3.5H2O = 3.5 H2O + SO4-2 + UO2+2
+    # Editor: Richter
+    log_k     -1.5854823687314
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    # Description: calculated from DRG298
+
+UO2(SO4):3H2O(cr)
+    UO2(SO4):3H2O = 3 H2O + SO4-2 + UO2+2
+    # Original equation: 0.5H2O(g) + UO2SO4:3H2O=UO2SO4:3.5H2O(cr)
+    # Editor: Richter
+    log_k     -1.504
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Additional reference: GRE/FUG1992
+    # Description: original equation: 0.5H2O(g) + UO2SO4:3H2O=UO2SO4:3.5H2O(cr) , original value 0.831+-0.023; with H2O(g) = H2O(l)  logK = 1.50 +- 0.03 and  UO2<2+> + SO4<-2> + 3.5 H2O = UO2SO4:3.5H2O logK = 1.585 +- 0.019
+
+UO2:H2O(ncr)
+    UO2:H2O + 4 H+ = 3 H2O + U+4
+    # Editor: Bok
+    log_k     -0.32
+    # Evaluation data class: 1, data quality: 1
+    # Reference: CEV2018
+    # Additional reference: YAN/CEV2023
+
+Uranophane
+    # Synonyms: Lambertite, Uranotile, Uranophane-α
+    Ca((UO2)2(SiO3OH)2):5H2O + 6 H+ = Ca+2 + 5 H2O + 2 Si(OH)4 + 2 UO2+2
+    # Editor: Richter
+    log_k     11.52
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GRE/GAO2020
+
+Vanthoffite
+    MgNa6(SO4)4 = Mg+2 + 6 Na+ + 4 SO4-2
+    # Editor: Freyer
+    log_k     -1.3281865513125
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      3.19847893152807E+1     -7.82581861266957E-2     -2.97562622745573E+3   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -Vm 203.915677 cm3/mol
+    # Reference: calculated from datatype RHO298, reference: BAL/PAM2020
+
+Vaterite
+    Ca(CO3) = CO3-2 + Ca+2
+    # Description: no formation data implemented
+    # Editor: Freyer
+    log_k     -7.9102507953296
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      1.39424485990147E+2   0     -5.92655659392491E+3     -5.15095315412832E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+Weeksite
+    K2((UO2)2(Si2O5)3):4H2O + 5 H2O + 6 H+ = 2 K+ + 6 Si(OH)4 + 2 UO2+2
+    # Editor: Richter
+    log_k     16.91
+    # Evaluation data class: 3, data quality: 3
+    # Reference: HEM1982
+    # Description: ATTENTION: [HEM1982] estimated DFG298=-9043+-25kJ/mol; no logK from solubility experiments are available, the here entered logK is calculated from DFG!, otherwise the mineral is relevant, and so the logK should be used with reservation
+
+Wegscheiderite
+    Na5(CO3)(HCO3)3 = 4 CO3-2 + 3 H+ + 5 Na+
+    # Editor: Freyer
+    log_k     -32.299577377196
+    # Notice: value was extrapolated from tp function
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      2.32408036794529E+3      9.67097889973038E-1      -6.6991802929612E+4     -9.61957592158278E+2   0     -4.46908844448159E-4 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 353.15 K - 373.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+
+Zincite
+    # Synonyms: Ancramite, Apartalite, Red Zinc Oxide, Spartalite
+    ZnO + 2 H+ = H2O + Zn+2
+    # Original equation: ZnO + H2O=Zn2+ + 2OH-
+    # Editor: Moog
+    log_k     11.35
+    # Evaluation data class: 1, data quality: 3
+    # Reference: HAG2022
+
+Zippeite
+    K3((UO2)4(SO4)2O3(OH)):3.3H2O + 7 H+ = 7.3 H2O + 3 K+ + 2 SO4-2 + 4 UO2+2
+    # Editor: Richter
+    log_k     4.14
+    # Evaluation data class: 1, data quality: 1
+    # Reference: SHA/SZY2016
+
+Zn(OH)2(am)
+    Zn(OH)2 + 2 H+ = 2 H2O + Zn+2
+    # Original equation: Zn(OH)2 (am)=Zn2+ + 2 OH-
+    # Editor: Moog
+    log_k     12.58
+    # Evaluation data class: 1, data quality: 3
+    # Reference: HAG2022
+
+Zn(OH)2_beta1(s)
+    Zn(OH)2 + 2 H+ = 2 H2O + Zn+2
+    # Original equation: b1-Zn(OH)2=Zn2+ + 2 OH-
+    # Editor: Moog
+    log_k     11.86
+    # Evaluation data class: 1, data quality: 2
+    # Reference: HAG2022
+
+Zn(OH)2_beta2(s)
+    Zn(OH)2 + 2 H+ = 2 H2O + Zn+2
+    # Original equation: b2-Zn(OH)2=Zn2+ + 2 OH-
+    # Editor: Moog
+    log_k     11.9
+    # Evaluation data class: 1, data quality: 2
+    # Reference: HAG2022
+
+Zn(OH)2_delta(s)
+    Zn(OH)2 + 2 H+ = 2 H2O + Zn+2
+    # Original equation: d-Zn(OH)2=Zn2+ + 2 OH-
+    # Editor: Moog
+    log_k     11.95
+    # Evaluation data class: 1, data quality: 2
+    # Reference: HAG2022
+
+Zn(OH)2_epsilon(s)
+    Zn(OH)2 + 2 H+ = 2 H2O + Zn+2
+    # Original equation: e-Zn(OH)2=Zn2+ + 2 OH-
+    # Editor: Moog
+    log_k     11.58
+    # Evaluation data class: 1, data quality: 2
+    # Reference: HAG2022
+
+Zn(OH)2_gamma(s)
+    Zn(OH)2 + 2 H+ = 2 H2O + Zn+2
+    # Original equation: g-Zn(OH)2=Zn2+ + 2 OH-
+    # Editor: Moog
+    log_k     11.84
+    # Evaluation data class: 1, data quality: 2
+    # Reference: HAG2022
+
+# ###### GASES #################################################################
+O2(g)
+   O2 = O2
+    # Editor: Moog
+    log_k     -2.904
+    # Evaluation data class: 1, data quality: 1
+    # Reference: BOK/MOO2023
+    -analytical_expression                -7.195E+1   0                 3.625E+3      2.29890095684526E+1   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+    -T_c 154.58 # critical T [K]
+    # Reference: POL/PRA2001
+    -P_c 49.77 # critical p [atm]
+    # Reference: POL/PRA2001
+    -Omega 0.022 # acentric factor
+    # Reference: CHA/CRU2021
+
+H2(g)
+   H2 = H2
+    # Editor: Bok
+    log_k     -3.1060872355098
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression              -5.29503E+1   0             2.4009753E+3       1.6889231398602E+1   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 353.15 K.
+    # Reference: YOU/BAT1981
+    # Description: Recalculated from equation 2 at page 1 of YOU/BAT1981: ln(x(H2))=-48.1611+55.2845/(T/100K)+16.8893ln(T/100K)
+    -T_c 33.25 # critical T [K]
+    # Reference: POL/PRA2001
+    -P_c 12.80 # critical p [atm]
+    # Reference: POL/PRA2001
+    -Omega -0.216 # acentric factor
+    # Reference: POL/PRA2001
+
+CO2(g)
+   CO2 + H2O = CO3-2 + 2 H+
+    # Description: original value 1.472+-0.020
+    # Original equation: CO2(aq) = CO2(g)
+    # Editor: Freyer
+    log_k     -18.152106769779
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression      1.32461253398587E+2   0     -6.88775534983129E+3     -5.15316615551146E+1   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -T_c 304.12 # critical T [K]
+    # Reference: POL/PRA2001
+    -P_c 72.78 # critical p [atm]
+    # Reference: POL/PRA2001
+    -Omega 0.225 # acentric factor
+    # Reference: POL/PRA2001
+
+H2O(g)
+   H2O = H2O
+    # Editor: Freyer
+    log_k     1.4993638383167
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CR
+    -analytical_expression     -2.50989927382907E+1     -2.49789022100348E-3       3.0358670276007E+3      6.88959726381623E+0   0      1.27002786286841E-6 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: internally calculated with calcmode = CTPFUNC
+    -T_c 647.14 # critical T [K]
+    # Reference: POL/PRA2001
+    -P_c 217.75 # critical p [atm]
+    # Reference: POL/PRA2001
+    -Omega 0.344 # acentric factor
+    # Reference: POL/PRA2001
+
+# ###### PITZER BLOCK ##########################################################
+PITZER
+-MacInnes false
+-use_etheta true
+-redox true
+
+# #### all beta- and cphi-coefficients #########################################
+-B0; (UO2)2(OH)2+2       Cl-                                  3.89E-1  0  0  0  0  0
+-B1; (UO2)2(OH)2+2       Cl-                                 2.259E+0  0  0  0  0  0
+-B2; (UO2)2(OH)2+2       Cl-                   0  0  0  0  0  0
+-C0; (UO2)2(OH)2+2       Cl-                   0  0  0  0  0  0
+-ALPHAS; (UO2)2(OH)2+2       Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Editor: Richter
+
+-B0; (UO2)3(OH)4+2       Cl-                                   8.0E-2  0  0  0  0  0
+-B1; (UO2)3(OH)4+2       Cl-                                   1.4E+0  0  0  0  0  0
+-B2; (UO2)3(OH)4+2       Cl-                   0  0  0  0  0  0
+-C0; (UO2)3(OH)4+2       Cl-                   0  0  0  0  0  0
+-ALPHAS; (UO2)3(OH)4+2       Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Editor: Richter
+
+-B0; (UO2)3(OH)5+        Cl-                                  1.46E-1  0  0  0  0  0
+-B1; (UO2)3(OH)5+        Cl-                                   6.0E-1  0  0  0  0  0
+-B2; (UO2)3(OH)5+        Cl-                   0  0  0  0  0  0
+-C0; (UO2)3(OH)5+        Cl-                   0  0  0  0  0  0
+-ALPHAS; (UO2)3(OH)5+        Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Editor: Richter
+
+-B0; (UO2)4(OH)7+        Cl-                                   2.3E-1  0  0  0  0  0
+-B1; (UO2)4(OH)7+        Cl-                                   3.0E-1  0  0  0  0  0
+-B2; (UO2)4(OH)7+        Cl-                   0  0  0  0  0  0
+-C0; (UO2)4(OH)7+        Cl-                   0  0  0  0  0  0
+-ALPHAS; (UO2)4(OH)7+        Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Editor: Richter
+
+-B0; Al(OH)2+            Cl-                                   9.0E-2  0  0  0  0  0
+-B1; Al(OH)2+            Cl-                                   3.4E-1  0  0  0  0  0
+-B2; Al(OH)2+            Cl-                   0  0  0  0  0  0
+-C0; Al(OH)2+            Cl-                   0  0  0  0  0  0
+-ALPHAS; Al(OH)2+            Cl-                                   2.0E+0  0
+    # Evaluation ip class: 3, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+-B0; Ca+2                Al(OH)4-              0  0  0  0  0  0
+-B1; Ca+2                Al(OH)4-              0  0  0  0  0  0
+-B2; Ca+2                Al(OH)4-              0  0  0  0  0  0
+-C0; Ca+2                Al(OH)4-              0  0  0  0  0  0
+-ALPHAS; Ca+2                Al(OH)4-              0  0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+-B0; H+                  Al(OH)4-              0  0  0  0  0  0
+-B1; H+                  Al(OH)4-              0  0  0  0  0  0
+-B2; H+                  Al(OH)4-              0  0  0  0  0  0
+-C0; H+                  Al(OH)4-              0  0  0  0  0  0
+-ALPHAS; H+                  Al(OH)4-              0  0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+-B0; K+                  Al(OH)4-                            1.008E-1               1.4701E+2  0              -7.8788E-4  0  0
+-B1; K+                  Al(OH)4-                            3.349E-1              -2.1511E+3  0              -1.7131E-2  0  0
+-B2; K+                  Al(OH)4-              0  0  0  0  0  0
+-C0; K+                  Al(OH)4-                             -3.5E-3              -2.2316E+1  0              -2.0222E-4  0  0
+-ALPHAS; K+                  Al(OH)4-                              2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+-B0; Mg+2                Al(OH)4-              0  0  0  0  0  0
+-B1; Mg+2                Al(OH)4-              0  0  0  0  0  0
+-B2; Mg+2                Al(OH)4-              0  0  0  0  0  0
+-C0; Mg+2                Al(OH)4-              0  0  0  0  0  0
+-ALPHAS; Mg+2                Al(OH)4-              0  0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+-B0; Na+                 Al(OH)4-                             6.79E-2              -9.8888E+1  0              -1.0479E-3  0  0
+-B1; Na+                 Al(OH)4-                            1.246E-1              -2.0611E+2  0              -1.2958E-3  0  0
+-B2; Na+                 Al(OH)4-              0  0  0  0  0  0
+-C0; Na+                 Al(OH)4-                             -3.1E-3                 1.73E+1  0               1.1827E-4  0  0
+-ALPHAS; Na+                 Al(OH)4-                              2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+-B0; Al+3                Cl-                                 6.993E-1  0  0  0  0  0
+-B1; Al+3                Cl-                                 5.845E+0  0  0  0  0  0
+-B2; Al+3                Cl-                   0  0  0  0  0  0
+-C0; Al+3                Cl-                   0  0  0  0  0  0
+-ALPHAS; Al+3                Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 373.15 K.
+    # Reference: MIR2023
+    # Additional reference: PIT/MAY1973
+    # Editor: Miron
+
+-B0; Al+3                SO4-2                                5.77E-1  0  0  0  0  0
+-B1; Al+3                SO4-2                                1.03E+1  0  0  0  0  0
+-B2; Al+3                SO4-2                               -2.33E+3  0  0                  4.8E+2                 -8.0E-1  0
+-C0; Al+3                SO4-2                                 7.0E-3  0  0  0  0  0
+-ALPHAS; Al+3                SO4-2                                 1.4E+0                  5.0E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 353.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+-B0; AlOH+2              Cl-                                   4.1E-1                  3.5E+1  0  0  0  0
+-B1; AlOH+2              Cl-                                  1.56E+0  0  0  0  0  0
+-B2; AlOH+2              Cl-                   0  0  0  0  0  0
+-C0; AlOH+2              Cl-                   0  0  0  0  0  0
+-ALPHAS; AlOH+2              Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 373.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+-B0; AlSiO(OH)3+2        Cl-                                  3.23E-1  0  0  0  0  0
+-B1; AlSiO(OH)3+2        Cl-                                  1.56E+0  0  0  0  0  0
+-B2; AlSiO(OH)3+2        Cl-                   0  0  0  0  0  0
+-C0; AlSiO(OH)3+2        Cl-                   0  0  0  0  0  0
+-ALPHAS; AlSiO(OH)3+2        Cl-                                   2.0E+0  0
+    # Evaluation ip class: 3, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+-B0; Am(CO3)+            Cl-                                  -7.2E-2  0  0  0  0  0
+-B1; Am(CO3)+            Cl-                                  4.03E-1  0  0  0  0  0
+-B2; Am(CO3)+            Cl-                   0  0  0  0  0  0
+-C0; Am(CO3)+            Cl-                                  3.88E-2  0  0  0  0  0
+-ALPHAS; Am(CO3)+            Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FAN/KON1999
+    # Additional reference: NEC/FAN1998
+    # Description: analogue value from: Cm(CO3)<+> and Cl<->
+    # Editor: Marquardt
+
+-B0; Am(NO3)2+           Cl-                                   2.5E-1  0  0  0  0  0
+-B1; Am(NO3)2+           Cl-                                   3.2E-1  0  0  0  0  0
+-B2; Am(NO3)2+           Cl-                   0  0  0  0  0  0
+-C0; Am(NO3)2+           Cl-                                   1.0E-1  0  0  0  0  0
+-ALPHAS; Am(NO3)2+           Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Am(NO3)2+           NO3-                                 4.16E-1  0  0  0  0  0
+-B1; Am(NO3)2+           NO3-                                 4.49E-1  0  0  0  0  0
+-B2; Am(NO3)2+           NO3-                  0  0  0  0  0  0
+-C0; Am(NO3)2+           NO3-                  0  0  0  0  0  0
+-ALPHAS; Am(NO3)2+           NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+-B0; Am(NO3)+2           Cl-                                   4.2E-1  0  0  0  0  0
+-B1; Am(NO3)+2           Cl-                                  1.83E+0  0  0  0  0  0
+-B2; Am(NO3)+2           Cl-                   0  0  0  0  0  0
+-C0; Am(NO3)+2           Cl-                                   5.0E-2  0  0  0  0  0
+-ALPHAS; Am(NO3)+2           Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Am(NO3)+2           NO3-                                 3.66E-1  0  0  0  0  0
+-B1; Am(NO3)+2           NO3-                                1.704E+0  0  0  0  0  0
+-B2; Am(NO3)+2           NO3-                  0  0  0  0  0  0
+-C0; Am(NO3)+2           NO3-                  0  0  0  0  0  0
+-ALPHAS; Am(NO3)+2           NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+-B0; Am(OH)2+            Cl-                                  -1.3E-1  0  0  0  0  0
+-B1; Am(OH)2+            Cl-                   0  0  0  0  0  0
+-B2; Am(OH)2+            Cl-                   0  0  0  0  0  0
+-C0; Am(OH)2+            Cl-                   0  0  0  0  0  0
+-ALPHAS; Am(OH)2+            Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: Corresponds to TRLFS-Data of Cm
+    # Editor: Marquardt
+
+-B0; Am(OH)2+            NO3-                                 -1.3E-1  0  0  0  0  0
+-B1; Am(OH)2+            NO3-                  0  0  0  0  0  0
+-B2; Am(OH)2+            NO3-                  0  0  0  0  0  0
+-C0; Am(OH)2+            NO3-                  0  0  0  0  0  0
+-ALPHAS; Am(OH)2+            NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Ca+2                Am(OH)4-              0  0  0  0  0  0
+-B1; Ca+2                Am(OH)4-              0  0  0  0  0  0
+-B2; Ca+2                Am(OH)4-              0  0  0  0  0  0
+-C0; Ca+2                Am(OH)4-              0  0  0  0  0  0
+-ALPHAS; Ca+2                Am(OH)4-                              2.0E+0  0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+-B0; K+                  Am(OH)4-              0  0  0  0  0  0
+-B1; K+                  Am(OH)4-              0  0  0  0  0  0
+-B2; K+                  Am(OH)4-              0  0  0  0  0  0
+-C0; K+                  Am(OH)4-              0  0  0  0  0  0
+-ALPHAS; K+                  Am(OH)4-                              2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: from interaction with Na<+>
+    # Editor: Marquardt
+
+-B0; Mg+2                Am(OH)4-              0  0  0  0  0  0
+-B1; Mg+2                Am(OH)4-              0  0  0  0  0  0
+-B2; Mg+2                Am(OH)4-              0  0  0  0  0  0
+-C0; Mg+2                Am(OH)4-              0  0  0  0  0  0
+-ALPHAS; Mg+2                Am(OH)4-                              2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: from interaction with Ca<2+>
+    # Editor: Marquardt
+
+-B0; Am(OH)+2            Cl-                                   5.5E-2  0  0  0  0  0
+-B1; Am(OH)+2            Cl-                                  1.81E+0  0  0  0  0  0
+-B2; Am(OH)+2            Cl-                   0  0  0  0  0  0
+-C0; Am(OH)+2            Cl-                   0  0  0  0  0  0
+-ALPHAS; Am(OH)+2            Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: Corresponds to TRLFS-Data of Cm
+    # Editor: Marquardt
+
+-B0; Am(OH)+2            NO3-                                  5.5E-2  0  0  0  0  0
+-B1; Am(OH)+2            NO3-                                 1.81E+0  0  0  0  0  0
+-B2; Am(OH)+2            NO3-                  0  0  0  0  0  0
+-C0; Am(OH)+2            NO3-                  0  0  0  0  0  0
+-ALPHAS; Am(OH)+2            NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Am(SO4)+            Cl-                                  -9.1E-2  0  0  0  0  0
+-B1; Am(SO4)+            Cl-                                  -3.9E-1  0  0  0  0  0
+-B2; Am(SO4)+            Cl-                   0  0  0  0  0  0
+-C0; Am(SO4)+            Cl-                                   4.8E-2  0  0  0  0  0
+-ALPHAS; Am(SO4)+            Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Description: analogue value from: Cm(SO4)<+>
+    # Editor: Marquardt
+
+-B0; Am(SO4)+            SO4-2                 0  0  0  0  0  0
+-B1; Am(SO4)+            SO4-2                 0  0  0  0  0  0
+-B2; Am(SO4)+            SO4-2                 0  0  0  0  0  0
+-C0; Am(SO4)+            SO4-2                 0  0  0  0  0  0
+-ALPHAS; Am(SO4)+            SO4-2                                 2.0E+0  0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Editor: Marquardt
+
+-B0; Am+3                Cl-                                 5.856E-1  0  0  0  0  0
+-B1; Am+3                Cl-                                   5.6E+0  0  0  0  0  0
+-B2; Am+3                Cl-                   0  0  0  0  0  0
+-C0; Am+3                Cl-                                  -1.6E-2  0  0  0  0  0
+-ALPHAS; Am+3                Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Nd<3+> (original data from PIT1991). Cphi calculated from Cm(III)-data KOE/FAN1997
+    # Editor: Marquardt
+
+-B0; Am+3                NO3-                                 5.93E-1  0  0  0  0  0
+-B1; Am+3                NO3-                                  5.6E+0  0  0  0  0  0
+-B2; Am+3                NO3-                  0  0  0  0  0  0
+-C0; Am+3                NO3-                  0  0  0  0  0  0
+-ALPHAS; Am+3                NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+-B0; Am+3                SO4-2                               1.792E+0  0  0  0  0  0
+-B1; Am+3                SO4-2                              1.5044E+1  0  0  0  0  0
+-B2; Am+3                SO4-2                 0  0  0  0  0  0
+-C0; Am+3                SO4-2                                -6.0E-1  0  0  0  0  0
+-ALPHAS; Am+3                SO4-2                                 2.0E+0  0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Additional reference: RAR1996
+    # Description: Calculated with isopiestic data of Lu2(SO4)3 from Rard, J.A., J. Chem. Thermodynamics 28, 83 (1996)
+    # Editor: Marquardt
+
+-B0; AmCl2+              Cl-                                  5.16E-1  0  0  0  0  0
+-B1; AmCl2+              Cl-                                  1.75E+0  0  0  0  0  0
+-B2; AmCl2+              Cl-                   0  0  0  0  0  0
+-C0; AmCl2+              Cl-                                   1.0E-2  0  0  0  0  0
+-ALPHAS; AmCl2+              Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: CmCl2<+>. Cm(III)-data from KON/FAN1997
+    # Editor: Marquardt
+
+-B0; AmCl2+              NO3-                                 5.16E-1  0  0  0  0  0
+-B1; AmCl2+              NO3-                                 1.75E+0  0  0  0  0  0
+-B2; AmCl2+              NO3-                  0  0  0  0  0  0
+-C0; AmCl2+              NO3-                                  1.0E-2  0  0  0  0  0
+-ALPHAS; AmCl2+              NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; AmCl+2              Cl-                                  5.93E-1  0  0  0  0  0
+-B1; AmCl+2              Cl-                                  3.15E+0  0  0  0  0  0
+-B2; AmCl+2              Cl-                   0  0  0  0  0  0
+-C0; AmCl+2              Cl-                                  -6.0E-3  0  0  0  0  0
+-ALPHAS; AmCl+2              Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: CmCl<2+>. Cm(III)-data from KON/FAN1997
+    # Editor: Marquardt
+
+-B0; AmCl+2              NO3-                                 5.93E-1  0  0  0  0  0
+-B1; AmCl+2              NO3-                                 3.15E+0  0  0  0  0  0
+-B2; AmCl+2              NO3-                  0  0  0  0  0  0
+-C0; AmCl+2              NO3-                                 -6.0E-3  0  0  0  0  0
+-ALPHAS; AmCl+2              NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Ca2(Am(OH)4)+3      Cl-                                   7.0E-1  0  0  0  0  0
+-B1; Ca2(Am(OH)4)+3      Cl-                                   4.3E+0  0  0  0  0  0
+-B2; Ca2(Am(OH)4)+3      Cl-                   0  0  0  0  0  0
+-C0; Ca2(Am(OH)4)+3      Cl-                   0  0  0  0  0  0
+-ALPHAS; Ca2(Am(OH)4)+3      Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Ca2[Cm(OH)4]<3+>; beta(1) fixed to 4.3 in accordance to a recommendation of GRE/PUI1997 in analogy to the charge type
+    # Editor: Marquardt
+
+-B0; Ca2(Am(OH)4)+3      NO3-                                  7.0E-1  0  0  0  0  0
+-B1; Ca2(Am(OH)4)+3      NO3-                                  4.3E+0  0  0  0  0  0
+-B2; Ca2(Am(OH)4)+3      NO3-                  0  0  0  0  0  0
+-C0; Ca2(Am(OH)4)+3      NO3-                  0  0  0  0  0  0
+-ALPHAS; Ca2(Am(OH)4)+3      NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Ca2(Cm(OH)4)+3      Cl-                                   7.0E-1  0  0  0  0  0
+-B1; Ca2(Cm(OH)4)+3      Cl-                                   4.3E+0  0  0  0  0  0
+-B2; Ca2(Cm(OH)4)+3      Cl-                   0  0  0  0  0  0
+-C0; Ca2(Cm(OH)4)+3      Cl-                   0  0  0  0  0  0
+-ALPHAS; Ca2(Cm(OH)4)+3      Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: value of beta1 fixed to 4.3 according to ist charge type on recommendation of GRE/PUI1997
+    # Editor: Marquardt
+
+-B0; Ca2(Cm(OH)4)+3      NO3-                                  7.0E-1  0  0  0  0  0
+-B1; Ca2(Cm(OH)4)+3      NO3-                                  4.3E+0  0  0  0  0  0
+-B2; Ca2(Cm(OH)4)+3      NO3-                  0  0  0  0  0  0
+-C0; Ca2(Cm(OH)4)+3      NO3-                  0  0  0  0  0  0
+-ALPHAS; Ca2(Cm(OH)4)+3      NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Ca2(Nd(OH)4)+3      Cl-                                   7.0E-1  0  0  0  0  0
+-B1; Ca2(Nd(OH)4)+3      Cl-                                   4.3E+0  0  0  0  0  0
+-B2; Ca2(Nd(OH)4)+3      Cl-                   0  0  0  0  0  0
+-C0; Ca2(Nd(OH)4)+3      Cl-                   0  0  0  0  0  0
+-ALPHAS; Ca2(Nd(OH)4)+3      Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Ca2[Cm(OH)4]<3+>; beta(1) fixed to 4.3 in accordance to a recommendation of GRE/PUI1997 in analogy to the charge type
+    # Editor: Marquardt
+
+-B0; Ca2(Nd(OH)4)+3      NO3-                                  7.0E-1  0  0  0  0  0
+-B1; Ca2(Nd(OH)4)+3      NO3-                                  4.3E+0  0  0  0  0  0
+-B2; Ca2(Nd(OH)4)+3      NO3-                  0  0  0  0  0  0
+-C0; Ca2(Nd(OH)4)+3      NO3-                  0  0  0  0  0  0
+-ALPHAS; Ca2(Nd(OH)4)+3      NO3-                                  2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Ca3TcO(OH)5+3       Cl-                                  -7.4E-2  0  0  0  0  0
+-B1; Ca3TcO(OH)5+3       Cl-                                   4.3E+0  0  0  0  0  0
+-B2; Ca3TcO(OH)5+3       Cl-                   0  0  0  0  0  0
+-C0; Ca3TcO(OH)5+3       Cl-                                   1.5E-2  0  0  0  0  0
+-ALPHAS; Ca3TcO(OH)5+3       Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/GAO2016
+    # Editor: Kiefer
+
+-B0; Ca3(Am(OH)6)+3      Cl-                                   3.7E-1  0  0  0  0  0
+-B1; Ca3(Am(OH)6)+3      Cl-                                   4.3E+0  0  0  0  0  0
+-B2; Ca3(Am(OH)6)+3      Cl-                   0  0  0  0  0  0
+-C0; Ca3(Am(OH)6)+3      Cl-                   0  0  0  0  0  0
+-ALPHAS; Ca3(Am(OH)6)+3      Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Ca3[Cm(OH)6]<3+>; beta(1) fixed to 4.3 in accordance to a recommendation of GRE/PUI1997 in analogy to the charge type
+    # Editor: Marquardt
+
+-B0; Ca3(Am(OH)6)+3      NO3-                                  3.7E-1  0  0  0  0  0
+-B1; Ca3(Am(OH)6)+3      NO3-                                  4.3E+0  0  0  0  0  0
+-B2; Ca3(Am(OH)6)+3      NO3-                  0  0  0  0  0  0
+-C0; Ca3(Am(OH)6)+3      NO3-                  0  0  0  0  0  0
+-ALPHAS; Ca3(Am(OH)6)+3      NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Ca3(Cm(OH)6)+3      Cl-                                   3.7E-1  0  0  0  0  0
+-B1; Ca3(Cm(OH)6)+3      Cl-                                   4.3E+0  0  0  0  0  0
+-B2; Ca3(Cm(OH)6)+3      Cl-                   0  0  0  0  0  0
+-C0; Ca3(Cm(OH)6)+3      Cl-                   0  0  0  0  0  0
+-ALPHAS; Ca3(Cm(OH)6)+3      Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: value of beta1 fixed to 4.3 according to ist charge type on recommendation of GRE/PUI1997
+    # Editor: Marquardt
+
+-B0; Ca3(Cm(OH)6)+3      NO3-                                  3.7E-1  0  0  0  0  0
+-B1; Ca3(Cm(OH)6)+3      NO3-                                  4.3E+0  0  0  0  0  0
+-B2; Ca3(Cm(OH)6)+3      NO3-                  0  0  0  0  0  0
+-C0; Ca3(Cm(OH)6)+3      NO3-                  0  0  0  0  0  0
+-ALPHAS; Ca3(Cm(OH)6)+3      NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Ca3(Nd(OH)6)+3      Cl-                                   3.7E-1  0  0  0  0  0
+-B1; Ca3(Nd(OH)6)+3      Cl-                                   4.3E+0  0  0  0  0  0
+-B2; Ca3(Nd(OH)6)+3      Cl-                   0  0  0  0  0  0
+-C0; Ca3(Nd(OH)6)+3      Cl-                   0  0  0  0  0  0
+-ALPHAS; Ca3(Nd(OH)6)+3      Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Ca3[Cm(OH)6]<3+>; beta(1) fixed to 4.3 in accordance to a recommendation of GRE/PUI1997 in analogy to the charge type
+    # Editor: Marquardt
+
+-B0; Ca3(Nd(OH)6)+3      NO3-                                  3.7E-1  0  0  0  0  0
+-B1; Ca3(Nd(OH)6)+3      NO3-                                  4.3E+0  0  0  0  0  0
+-B2; Ca3(Nd(OH)6)+3      NO3-                  0  0  0  0  0  0
+-C0; Ca3(Nd(OH)6)+3      NO3-                  0  0  0  0  0  0
+-ALPHAS; Ca3(Nd(OH)6)+3      NO3-                                  2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Ca3(NpO2(OH)5)+2    Cl-                                 -7.92E-2  0  0  0  0  0
+-B1; Ca3(NpO2(OH)5)+2    Cl-                                1.2043E+0  0  0  0  0  0
+-B2; Ca3(NpO2(OH)5)+2    Cl-                   0  0  0  0  0  0
+-C0; Ca3(NpO2(OH)5)+2    Cl-                                  1.03E-2  0  0  0  0  0
+-ALPHAS; Ca3(NpO2(OH)5)+2    Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FEL/ALT2016
+    # Editor: Gaona
+
+-B0; Ca4(Np(OH)8)+4      Cl-                                   5.8E-1  0  0  0  0  0
+-B1; Ca4(Np(OH)8)+4      Cl-                                   8.9E+0  0  0  0  0  0
+-B2; Ca4(Np(OH)8)+4      Cl-                   0  0  0  0  0  0
+-C0; Ca4(Np(OH)8)+4      Cl-                                   7.0E-2  0  0  0  0  0
+-ALPHAS; Ca4(Np(OH)8)+4      Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FEL/NEC2010
+    # Editor: Marquardt
+
+-B0; Ca4(Pu(OH)8)+4      Cl-                                   5.8E-1  0  0  0  0  0
+-B1; Ca4(Pu(OH)8)+4      Cl-                                   8.9E+0  0  0  0  0  0
+-B2; Ca4(Pu(OH)8)+4      Cl-                   0  0  0  0  0  0
+-C0; Ca4(Pu(OH)8)+4      Cl-                                   7.0E-2  0  0  0  0  0
+-ALPHAS; Ca4(Pu(OH)8)+4      Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FEL/NEC2010
+    # Description: based on data for analogous Ca4[Th(OH)8]<4+> complex
+    # Editor: Marquardt
+
+-B0; Ca4(Th(OH)8)+4      Cl-                                   5.8E-1  0  0  0  0  0
+-B1; Ca4(Th(OH)8)+4      Cl-                                   8.9E+0  0  0  0  0  0
+-B2; Ca4(Th(OH)8)+4      Cl-                   0  0  0  0  0  0
+-C0; Ca4(Th(OH)8)+4      Cl-                                   7.0E-2  0  0  0  0  0
+-ALPHAS; Ca4(Th(OH)8)+4      Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FEL/NEC2010
+    # Editor: Marquardt
+
+-B0; Ca4(U(OH)8)+4       Cl-                                   5.8E-1  0  0  0  0  0
+-B1; Ca4(U(OH)8)+4       Cl-                                   8.9E+0  0  0  0  0  0
+-B2; Ca4(U(OH)8)+4       Cl-                   0  0  0  0  0  0
+-C0; Ca4(U(OH)8)+4       Cl-                                   7.0E-2  0  0  0  0  0
+-ALPHAS; Ca4(U(OH)8)+4       Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FEL/NEC2010
+    # Additional reference: YAN/CEV2023
+    # Editor: Richter
+
+-B0; Ca+2                CO3-2                 0  0  0  0  0  0
+-B1; Ca+2                CO3-2                 0  0  0  0  0  0
+-B2; Ca+2                CO3-2                 0  0  0  0  0  0
+-C0; Ca+2                CO3-2                 0  0  0  0  0  0
+-ALPHAS; Ca+2                CO3-2                                 1.4E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+-B0; Ca+2                Cl-                       3.0654497147407E-1     5.23608186384246E+5     2.22855799524205E+3    -4.19718905646762E+0     1.47522004931144E-3    -2.29716385982982E+7
+-B1; Ca+2                Cl-                       1.7081116892327E+0  0  0    -1.54168146009983E-2     3.17906175957664E-5  0
+-B2; Ca+2                Cl-                   0  0  0  0  0  0
+-C0; Ca+2                Cl-                        2.224452591463E-3    -4.94500185265404E+4    -2.10953653516146E+2     3.98063953334536E-1    -1.40189055264899E-4     2.16526128601977E+6
+-ALPHAS; Ca+2                Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+-B0; Ca+2                HCO3-                                 2.8E-1  0  0  0  0  0
+-B1; Ca+2                HCO3-                                 3.0E-1  0  0  0  0  0
+-B2; Ca+2                HCO3-                 0  0  0  0  0  0
+-C0; Ca+2                HCO3-                 0  0  0  0  0  0
+-ALPHAS; Ca+2                HCO3-                                 2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Description: 
+    # Editor: Freyer
+
+-B0; Ca+2                HSO4-                     2.9864096296195E-1     9.88074465091106E+2     7.62426657044921E+0    -1.43060665103133E-2  0  0
+-B1; Ca+2                HSO4-                     2.3635849121353E+0  0    -1.90681323591316E+1     6.42052608094293E-2  0  0
+-B2; Ca+2                HSO4-                 0  0  0  0  0  0
+-C0; Ca+2                HSO4-                 0  0  0  0  0  0
+-ALPHAS; Ca+2                HSO4-                                 2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+-B0; Ca+2                NO3-                               1.3429E-1  0  0  0  0  0
+-B1; Ca+2                NO3-                             1.116585E+0  0  0  0  0  0
+-B2; Ca+2                NO3-                  0  0  0  0  0  0
+-C0; Ca+2                NO3-                               -2.986E-3  0  0  0  0  0
+-ALPHAS; Ca+2                NO3-                                  1.4E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MUN2024
+    # Editor: Kiefer
+
+-B0; Ca+2                OH-                      -1.0982596597323E-1     4.15172956040652E+2  0     2.64073943953335E-4  0  0
+-B1; Ca+2                OH-                                -2.303E-1  0  0  0  0  0
+-B2; Ca+2                OH-                                 -5.72E+0  0  0  0  0  0
+-C0; Ca+2                OH-                   0  0  0  0  0  0
+-ALPHAS; Ca+2                OH-                                   2.0E+0                  5.0E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+-B0; Ca+2                PbCl3-                              1.908E-1  0  0  0  0  0
+-B1; Ca+2                PbCl3-                              5.348E-1  0  0  0  0  0
+-B2; Ca+2                PbCl3-                0  0  0  0  0  0
+-C0; Ca+2                PbCl3-                0  0  0  0  0  0
+-ALPHAS; Ca+2                PbCl3-                                2.0E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Editor: Moog
+
+-B0; Ca+2                PbCl4-2                             1.465E-1  0  0  0  0  0
+-B1; Ca+2                PbCl4-2                             5.458E+0  0  0  0  0  0
+-B2; Ca+2                PbCl4-2               0  0  0  0  0  0
+-C0; Ca+2                PbCl4-2                             3.544E-2  0  0  0  0  0
+-ALPHAS; Ca+2                PbCl4-2                               1.4E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Description: Original value in [HAG1999]: cgamma = 0.00886 +/- 0.0008. For THEREDA cphi = 0.03544 +/- 0.0032.
+    # Editor: Moog
+
+-B0; Ca+2                SO4-2                     1.9974354984288E-1     5.52771709545914E+4     4.57918413407902E+2    -1.25119301100487E+0     5.61539689698719E-4  0
+-B1; Ca+2                SO4-2                      3.197393958153E+0     -8.0237681510341E+4    -6.65416214901678E+2     1.84005549582055E+0    -8.41657491129954E-4  0
+-B2; Ca+2                SO4-2                    -5.4567258536473E+1  0  0       5.813966191593E-1  0  0
+-C0; Ca+2                SO4-2                 0  0  0  0  0  0
+-ALPHAS; Ca+2                SO4-2                                 1.4E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+-B0; CaSiO(OH)3+         Cl-                                   9.0E-2  0  0  0  0  0
+-B1; CaSiO(OH)3+         Cl-                                   3.4E-1  0  0  0  0  0
+-B2; CaSiO(OH)3+         Cl-                   0  0  0  0  0  0
+-C0; CaSiO(OH)3+         Cl-                   0  0  0  0  0  0
+-ALPHAS; CaSiO(OH)3+         Cl-                                   2.0E+0  0
+    # Evaluation ip class: 3, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Additional reference: PLY/FAN1998
+    # Editor: Miron
+
+-B0; Ca(Am(OH)3)+2       Cl-                                   2.1E-1  0  0  0  0  0
+-B1; Ca(Am(OH)3)+2       Cl-                                   1.6E+0  0  0  0  0  0
+-B2; Ca(Am(OH)3)+2       Cl-                   0  0  0  0  0  0
+-C0; Ca(Am(OH)3)+2       Cl-                   0  0  0  0  0  0
+-ALPHAS; Ca(Am(OH)3)+2       Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Ca[Cm(OH)3]<2+>; beta(1) fixed to 1.6 in accordance to a recommendation of GRE/PUI1997 in analogy to the charge type
+    # Editor: Marquardt
+
+-B0; Ca(Am(OH)3)+2       NO3-                                  2.1E-1  0  0  0  0  0
+-B1; Ca(Am(OH)3)+2       NO3-                                  1.6E+0  0  0  0  0  0
+-B2; Ca(Am(OH)3)+2       NO3-                  0  0  0  0  0  0
+-C0; Ca(Am(OH)3)+2       NO3-                  0  0  0  0  0  0
+-ALPHAS; Ca(Am(OH)3)+2       NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Ca(Cm(OH)3)+2       Cl-                                   2.1E-1  0  0  0  0  0
+-B1; Ca(Cm(OH)3)+2       Cl-                                   1.6E+0  0  0  0  0  0
+-B2; Ca(Cm(OH)3)+2       Cl-                   0  0  0  0  0  0
+-C0; Ca(Cm(OH)3)+2       Cl-                   0  0  0  0  0  0
+-ALPHAS; Ca(Cm(OH)3)+2       Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: value of beta1 fixed to 1.6 according to ist charge type on recommendation of GRE/PUI1997
+    # Editor: Marquardt
+
+-B0; Ca(Cm(OH)3)+2       NO3-                                  2.1E-1  0  0  0  0  0
+-B1; Ca(Cm(OH)3)+2       NO3-                                  1.6E+0  0  0  0  0  0
+-B2; Ca(Cm(OH)3)+2       NO3-                  0  0  0  0  0  0
+-C0; Ca(Cm(OH)3)+2       NO3-                  0  0  0  0  0  0
+-ALPHAS; Ca(Cm(OH)3)+2       NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Ca(Nd(OH)3)+2       Cl-                                   2.1E-1  0  0  0  0  0
+-B1; Ca(Nd(OH)3)+2       Cl-                                   1.6E+0  0  0  0  0  0
+-B2; Ca(Nd(OH)3)+2       Cl-                   0  0  0  0  0  0
+-C0; Ca(Nd(OH)3)+2       Cl-                   0  0  0  0  0  0
+-ALPHAS; Ca(Nd(OH)3)+2       Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Ca[Cm(OH)3]<2+>; beta(1) fixed to 1.6 in accordance to a recommendation of GRE/PUI1997 in analogy to the charge type
+    # Editor: Marquardt
+
+-B0; Ca(Nd(OH)3)+2       NO3-                                  2.1E-1  0  0  0  0  0
+-B1; Ca(Nd(OH)3)+2       NO3-                                  1.6E+0  0  0  0  0  0
+-B2; Ca(Nd(OH)3)+2       NO3-                  0  0  0  0  0  0
+-C0; Ca(Nd(OH)3)+2       NO3-                  0  0  0  0  0  0
+-ALPHAS; Ca(Nd(OH)3)+2       NO3-                                  2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Ca(NpO2(OH)2)+      Cl-                                 -3.18E-2  0  0  0  0  0
+-B1; Ca(NpO2(OH)2)+      Cl-                                 2.945E-1  0  0  0  0  0
+-B2; Ca(NpO2(OH)2)+      Cl-                   0  0  0  0  0  0
+-C0; Ca(NpO2(OH)2)+      Cl-                                  -3.1E-3  0  0  0  0  0
+-ALPHAS; Ca(NpO2(OH)2)+      Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FEL/ALT2016
+    # Editor: Gaona
+
+-B0; K+                  Cd(CO3)2-2                         -9.614E-2  0  0  0  0  0
+-B1; K+                  Cd(CO3)2-2            0  0  0  0  0  0
+-B2; K+                  Cd(CO3)2-2            0  0  0  0  0  0
+-C0; K+                  Cd(CO3)2-2            0  0  0  0  0  0
+-ALPHAS; K+                  Cd(CO3)2-2                            2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2024
+    # Description: Value for alpha(1) not stated in the source, but confirmed in personal communication with the author.
+    # Editor: Moog
+
+-B0; Na+                 Cd(CO3)2-2                        -1.4171E-1  0  0  0  0  0
+-B1; Na+                 Cd(CO3)2-2            0  0  0  0  0  0
+-B2; Na+                 Cd(CO3)2-2            0  0  0  0  0  0
+-C0; Na+                 Cd(CO3)2-2            0  0  0  0  0  0
+-ALPHAS; Na+                 Cd(CO3)2-2                            2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2024
+    # Description: Value for alpha(1) not stated in the source, but confirmed in personal communication with the author.
+    # Editor: Moog
+
+-B0; K+                  Cd(OH)4-2                            5.05E-1  0  0  0  0  0
+-B1; K+                  Cd(OH)4-2                           2.813E+0  0  0  0  0  0
+-B2; K+                  Cd(OH)4-2             0  0  0  0  0  0
+-C0; K+                  Cd(OH)4-2             0  0  0  0  0  0
+-ALPHAS; K+                  Cd(OH)4-2                             2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2024
+    # Editor: Moog
+
+-B0; Na+                 Cd(OH)4-2                            2.55E-1  0  0  0  0  0
+-B1; Na+                 Cd(OH)4-2                           4.286E+0  0  0  0  0  0
+-B2; Na+                 Cd(OH)4-2             0  0  0  0  0  0
+-C0; Na+                 Cd(OH)4-2             0  0  0  0  0  0
+-ALPHAS; Na+                 Cd(OH)4-2                             2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2024
+    # Editor: Moog
+
+-B0; Cd+2                Cl-                                -4.008E-2  0  0  0  0  0
+-B1; Cd+2                Cl-                               -3.1761E+0  0  0  0  0  0
+-B2; Cd+2                Cl-                              -4.49301E+1  0  0  0  0  0
+-C0; Cd+2                Cl-                                  5.32E-3  0  0  0  0  0
+-ALPHAS; Cd+2                Cl-                                   2.5E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2024
+    # Description: Original value for C_gamma = 0.00188
+    # Editor: Moog
+
+-B0; Cd+2                NO3-                                2.794E-1  0  0  0  0  0
+-B1; Cd+2                NO3-                              1.77126E+0  0  0  0  0  0
+-B2; Cd+2                NO3-                  0  0  0  0  0  0
+-C0; Cd+2                NO3-                               -2.336E-2  0  0  0  0  0
+-ALPHAS; Cd+2                NO3-                                  2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2024
+    # Editor: Moog
+
+-B0; Cd+2                SO4-2                              2.2487E-1  0  0  0  0  0
+-B1; Cd+2                SO4-2                              2.3385E+0  0  0  0  0  0
+-B2; Cd+2                SO4-2                             -5.9824E+1  0  0  0  0  0
+-C0; Cd+2                SO4-2                               5.208E-3  0  0  0  0  0
+-ALPHAS; Cd+2                SO4-2                                 1.4E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2024
+    # Description: Original value for C_gamma = 0.001302
+    # Editor: Moog
+
+-B0; Cm(CO3)+            Cl-                                  -7.2E-2  0  0  0  0  0
+-B1; Cm(CO3)+            Cl-                                  4.03E-1  0  0  0  0  0
+-B2; Cm(CO3)+            Cl-                   0  0  0  0  0  0
+-C0; Cm(CO3)+            Cl-                                  3.88E-2  0  0  0  0  0
+-ALPHAS; Cm(CO3)+            Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FAN/KON1999
+    # Additional reference: NEC/FAN1998
+    # Editor: Marquardt
+
+-B0; Cm(NO3)2+           Cl-                                   2.5E-1  0  0  0  0  0
+-B1; Cm(NO3)2+           Cl-                                   3.2E-1  0  0  0  0  0
+-B2; Cm(NO3)2+           Cl-                   0  0  0  0  0  0
+-C0; Cm(NO3)2+           Cl-                                   1.0E-1  0  0  0  0  0
+-ALPHAS; Cm(NO3)2+           Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Cm(NO3)2+           NO3-                                 4.16E-1  0  0  0  0  0
+-B1; Cm(NO3)2+           NO3-                                 4.49E-1  0  0  0  0  0
+-B2; Cm(NO3)2+           NO3-                  0  0  0  0  0  0
+-C0; Cm(NO3)2+           NO3-                  0  0  0  0  0  0
+-ALPHAS; Cm(NO3)2+           NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+-B0; Cm(NO3)+2           Cl-                                   4.2E-1  0  0  0  0  0
+-B1; Cm(NO3)+2           Cl-                                  1.83E+0  0  0  0  0  0
+-B2; Cm(NO3)+2           Cl-                   0  0  0  0  0  0
+-C0; Cm(NO3)+2           Cl-                                   5.0E-2  0  0  0  0  0
+-ALPHAS; Cm(NO3)+2           Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Cm(NO3)+2           NO3-                                 3.66E-1  0  0  0  0  0
+-B1; Cm(NO3)+2           NO3-                                1.704E+0  0  0  0  0  0
+-B2; Cm(NO3)+2           NO3-                  0  0  0  0  0  0
+-C0; Cm(NO3)+2           NO3-                  0  0  0  0  0  0
+-ALPHAS; Cm(NO3)+2           NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+-B0; Cm(OH)2+            Cl-                                  -1.3E-1  0  0  0  0  0
+-B1; Cm(OH)2+            Cl-                   0  0  0  0  0  0
+-B2; Cm(OH)2+            Cl-                   0  0  0  0  0  0
+-C0; Cm(OH)2+            Cl-                   0  0  0  0  0  0
+-ALPHAS; Cm(OH)2+            Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Nd(OH)2<+> and Am(OH)2<+>
+    # Editor: Marquardt
+
+-B0; Cm(OH)2+            NO3-                                 -1.3E-1  0  0  0  0  0
+-B1; Cm(OH)2+            NO3-                  0  0  0  0  0  0
+-B2; Cm(OH)2+            NO3-                  0  0  0  0  0  0
+-C0; Cm(OH)2+            NO3-                  0  0  0  0  0  0
+-ALPHAS; Cm(OH)2+            NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Cm(OH)+2            Cl-                                   5.5E-2  0  0  0  0  0
+-B1; Cm(OH)+2            Cl-                                  1.81E+0  0  0  0  0  0
+-B2; Cm(OH)+2            Cl-                   0  0  0  0  0  0
+-C0; Cm(OH)+2            Cl-                   0  0  0  0  0  0
+-ALPHAS; Cm(OH)+2            Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: ALT/BRE2004
+    # Additional reference: NEC/FAN1998
+    # Description: The parameter set was deduced by using Cm(III) as well as Am(III) hydrolysis data as described in NEC/FAN1998.
+    # Editor: Marquardt
+
+-B0; Cm(OH)+2            NO3-                                  5.5E-2  0  0  0  0  0
+-B1; Cm(OH)+2            NO3-                                 1.81E+0  0  0  0  0  0
+-B2; Cm(OH)+2            NO3-                  0  0  0  0  0  0
+-C0; Cm(OH)+2            NO3-                  0  0  0  0  0  0
+-ALPHAS; Cm(OH)+2            NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Cm(SO4)+            Cl-                                  -9.1E-2  0  0  0  0  0
+-B1; Cm(SO4)+            Cl-                                  -3.9E-1  0  0  0  0  0
+-B2; Cm(SO4)+            Cl-                   0  0  0  0  0  0
+-C0; Cm(SO4)+            Cl-                                   4.8E-2  0  0  0  0  0
+-ALPHAS; Cm(SO4)+            Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Editor: Marquardt
+
+-B0; Cm(SO4)+            SO4-2                 0  0  0  0  0  0
+-B1; Cm(SO4)+            SO4-2                 0  0  0  0  0  0
+-B2; Cm(SO4)+            SO4-2                 0  0  0  0  0  0
+-C0; Cm(SO4)+            SO4-2                 0  0  0  0  0  0
+-ALPHAS; Cm(SO4)+            SO4-2                                 2.0E+0  0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Editor: Marquardt
+
+-B0; Cm+3                Cl-                                 5.856E-1  0  0  0  0  0
+-B1; Cm+3                Cl-                                   5.6E+0  0  0  0  0  0
+-B2; Cm+3                Cl-                   0  0  0  0  0  0
+-C0; Cm+3                Cl-                                  -1.6E-2  0  0  0  0  0
+-ALPHAS; Cm+3                Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Nd<3+> (original data from PIT1991, p. 109, Tab. 9). Cphi calculated from Cm(III)-data KOE/FAN1997
+    # Editor: Marquardt
+
+-B0; Cm+3                NO3-                                 5.93E-1  0  0  0  0  0
+-B1; Cm+3                NO3-                                  5.6E+0  0  0  0  0  0
+-B2; Cm+3                NO3-                  0  0  0  0  0  0
+-C0; Cm+3                NO3-                  0  0  0  0  0  0
+-ALPHAS; Cm+3                NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+-B0; Cm+3                SO4-2                               1.792E+0  0  0  0  0  0
+-B1; Cm+3                SO4-2                              1.5044E+1  0  0  0  0  0
+-B2; Cm+3                SO4-2                 0  0  0  0  0  0
+-C0; Cm+3                SO4-2                                -6.0E-1  0  0  0  0  0
+-ALPHAS; Cm+3                SO4-2                                 2.0E+0  0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Description: analogue value from: Lu<3+>
+    # Editor: Marquardt
+
+-B0; CmCl2+              Cl-                                  5.16E-1  0  0  0  0  0
+-B1; CmCl2+              Cl-                                  1.75E+0  0  0  0  0  0
+-B2; CmCl2+              Cl-                   0  0  0  0  0  0
+-C0; CmCl2+              Cl-                                   1.0E-2  0  0  0  0  0
+-ALPHAS; CmCl2+              Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: Cm(III) data from KOE/FAN1997
+    # Editor: Marquardt
+
+-B0; CmCl2+              NO3-                                 5.16E-1  0  0  0  0  0
+-B1; CmCl2+              NO3-                                 1.75E+0  0  0  0  0  0
+-B2; CmCl2+              NO3-                  0  0  0  0  0  0
+-C0; CmCl2+              NO3-                                  1.0E-2  0  0  0  0  0
+-ALPHAS; CmCl2+              NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; CmCl+2              Cl-                                  5.93E-1  0  0  0  0  0
+-B1; CmCl+2              Cl-                                  3.15E+0  0  0  0  0  0
+-B2; CmCl+2              Cl-                   0  0  0  0  0  0
+-C0; CmCl+2              Cl-                                  -6.0E-3  0  0  0  0  0
+-ALPHAS; CmCl+2              Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: Cm(III) data from KON/FAN1997
+    # Editor: Marquardt
+
+-B0; CmCl+2              NO3-                                 5.93E-1  0  0  0  0  0
+-B1; CmCl+2              NO3-                                 3.15E+0  0  0  0  0  0
+-B2; CmCl+2              NO3-                  0  0  0  0  0  0
+-C0; CmCl+2              NO3-                                 -6.0E-3  0  0  0  0  0
+-ALPHAS; CmCl+2              NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Cs+                 Cl-                                 3.676E-2  0  0  0  0  0
+-B1; Cs+                 Cl-                                  -5.0E-4  0  0  0  0  0
+-B2; Cs+                 Cl-                                 3.259E-1  0  0  0  0  0
+-C0; Cs+                 Cl-                                   2.4E-4  0  0  0  0  0
+-ALPHAS; Cs+                 Cl-                                  -1.0E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2012
+    # Editor: Moog
+
+-B0; Cs+                 SO4-2                               9.849E-2  0  0  0  0  0
+-B1; Cs+                 SO4-2                              5.3084E-1  0  0  0  0  0
+-B2; Cs+                 SO4-2                 0  0  0  0  0  0
+-C0; Cs+                 SO4-2                                -3.0E-3  0  0  0  0  0
+-ALPHAS; Cs+                 SO4-2                                 2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2012
+    # Editor: Moog
+
+-B0; H+                  CO3-2                 0  0  0  0  0  0
+-B1; H+                  CO3-2                 0  0  0  0  0  0
+-B2; H+                  CO3-2                 0  0  0  0  0  0
+-C0; H+                  CO3-2                 0  0  0  0  0  0
+-ALPHAS; H+                  CO3-2                 0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+-B0; H+                  Cl-                       1.7621966566776E-1     9.90122197847134E+3     5.00672152023573E+1    -1.09028292019965E-1     4.28321318179085E-5     -3.5102615442901E+5
+-B1; H+                  Cl-                       2.9952169750777E-1     1.89788670755908E+5     7.76484447411149E+2    -1.39639369414878E+0     4.67182180527993E-4    -8.59926099585062E+6
+-B2; H+                  Cl-                   0  0  0  0  0  0
+-C0; H+                  Cl-                   0  0  0  0  0  0
+-ALPHAS; H+                  Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+-B0; H+                  HCO3-                 0  0  0  0  0  0
+-B1; H+                  HCO3-                 0  0  0  0  0  0
+-B2; H+                  HCO3-                 0  0  0  0  0  0
+-C0; H+                  HCO3-                 0  0  0  0  0  0
+-ALPHAS; H+                  HCO3-                 0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+-B0; H+                  HSO4-                     2.1041734438917E-1    -3.77910704311745E+3     -2.1070988995129E+1     5.20151099885742E-2    -2.39977268627097E-5     1.34621036502496E+5
+-B1; H+                  HSO4-                     4.4112969327247E-1  0  0     1.60077790606771E-3    -2.68451771002466E-6  0
+-B2; H+                  HSO4-                 0  0  0  0  0  0
+-C0; H+                  HSO4-                 0  0  0  0  0  0
+-ALPHAS; H+                  HSO4-                                 2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+-B0; H+                  NO3-                             1.065751E-1  0  0  0  0  0
+-B1; H+                  NO3-                             4.583727E-1  0  0  0  0  0
+-B2; H+                  NO3-                  0  0  0  0  0  0
+-C0; H+                  NO3-                              2.18752E-3  0  0  0  0  0
+-ALPHAS; H+                  NO3-                                  2.0E+0  0
+    # Evaluation ip class: 1, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: LAC/AND2018
+    # Editor: Kiefer
+
+-B0; H+                  OH-                   0  0  0  0  0  0
+-B1; H+                  OH-                   0  0  0  0  0  0
+-B2; H+                  OH-                   0  0  0  0  0  0
+-C0; H+                  OH-                   0  0  0  0  0  0
+-ALPHAS; H+                  OH-                   0  0
+    # Evaluation ip class: 0, data quality: 0
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+-B0; H+                  SO4-2                     9.1034198373222E-2     1.82163704131337E+4     1.01572107510975E+2    -2.63425179866498E-1     1.30352409645799E-4    -6.48886469661435E+5
+-B1; H+                  SO4-2                 0  0  0  0  0  0
+-B2; H+                  SO4-2                 0  0  0  0  0  0
+-C0; H+                  SO4-2                      5.523480074379E-2     1.24417006554814E+4     6.93710303084972E+1     -1.7062382103554E-1     7.50016648024535E-5    -4.43201095676228E+5
+-ALPHAS; H+                  SO4-2                                 2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+-B0; K+                  HSeO3-                              2.675E-2  0  0  0  0  0
+-B1; K+                  HSeO3-                            1.42414E+0  0  0  0  0  0
+-B2; K+                  HSeO3-                0  0  0  0  0  0
+-C0; K+                  HSeO3-                0  0  0  0  0  0
+-ALPHAS; K+                  HSeO3-                                2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG/MOO2012
+    # Description: C calculated from C
+    # Editor: Bok
+
+-B0; Na+                 HSeO3-                            -1.1281E-1  0  0  0  0  0
+-B1; Na+                 HSeO3-                            1.77141E+0  0  0  0  0  0
+-B2; Na+                 HSeO3-                0  0  0  0  0  0
+-C0; Na+                 HSeO3-                0  0  0  0  0  0
+-ALPHAS; Na+                 HSeO3-                                2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG/MOO2012
+    # Description: C calculated from C
+    # Editor: Bok
+
+-B0; K+                  (UO2)3(OH)7-                         -2.6E-1  0  0  0  0  0
+-B1; K+                  (UO2)3(OH)7-                          3.4E-1  0  0  0  0  0
+-B2; K+                  (UO2)3(OH)7-          0  0  0  0  0  0
+-C0; K+                  (UO2)3(OH)7-          0  0  0  0  0  0
+-ALPHAS; K+                  (UO2)3(OH)7-                          2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Editor: Richter
+
+-B0; K+                  CO3-2                               1.488E-1  0  0  0  0  0
+-B1; K+                  CO3-2                                1.43E+0  0  0  0  0  0
+-B2; K+                  CO3-2                 0  0  0  0  0  0
+-C0; K+                  CO3-2                                -1.5E-3  0  0  0  0  0
+-ALPHAS; K+                  CO3-2                                 2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+-B0; K+                  Cl-                       4.8079377548731E-2     -7.5847633050695E+2     -4.7061851476336E+0      1.0071983860725E-2     -3.7598981538277E-6  0
+-B1; K+                  Cl-                       2.1807681736709E-1      1.1219316841662E+5      4.7832163208852E+2     -9.0718308906128E-1      3.2392910397498E-4     -4.9466617980636E+6
+-B2; K+                  Cl-                   0  0  0  0  0  0
+-C0; K+                  Cl-                      -7.8798909643085E-4      9.1270112261712E+1      5.8644312766853E-1     -1.2980628672801E-3      4.9570761092068E-7  0
+-ALPHAS; K+                  Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+-B0; K+                  H2PO4-                            -1.1116E-1  0  0  0  0  0
+-B1; K+                  H2PO4-                              4.699E-2  0  0  0  0  0
+-B2; K+                  H2PO4-                0  0  0  0  0  0
+-C0; K+                  H2PO4-                               1.97E-2  0  0  0  0  0
+-ALPHAS; K+                  H2PO4-                                2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2013a
+    # Editor: Moog
+
+-B0; K+                  HCO3-                                2.96E-2  0  0  0  0  0
+-B1; K+                  HCO3-                                -1.3E-2  0  0  0  0  0
+-B2; K+                  HCO3-                 0  0  0  0  0  0
+-C0; K+                  HCO3-                                -8.0E-3  0  0  0  0  0
+-ALPHAS; K+                  HCO3-                                 2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+-B0; K+                  HPO4-2                              5.884E-2  0  0  0  0  0
+-B1; K+                  HPO4-2                            1.06932E+0  0  0  0  0  0
+-B2; K+                  HPO4-2                0  0  0  0  0  0
+-C0; K+                  HPO4-2                                1.2E-4  0  0  0  0  0
+-ALPHAS; K+                  HPO4-2                                2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2013a
+    # Editor: Moog
+
+-B0; K+                  HSO4-                    -2.9999639184557E-4  0  0  0  0  0
+-B1; K+                  HSO4-                     1.2027181430032E-2  0  0  0  0  0
+-B2; K+                  HSO4-                 0  0  0  0  0  0
+-C0; K+                  HSO4-                     5.3772255469336E-4     7.12557332371159E+0  0     2.28653250345781E-4     -1.8366779120813E-7  0
+-ALPHAS; K+                  HSO4-                                 2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+-B0; K+                  NO3-                               -7.914E-2  0  0  0  0  0
+-B1; K+                  NO3-                                4.937E-2  0  0  0  0  0
+-B2; K+                  NO3-                  0  0  0  0  0  0
+-C0; K+                  NO3-                                 6.42E-3  0  0  0  0  0
+-ALPHAS; K+                  NO3-                                  2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MUN2024
+    # Editor: Kiefer
+
+-B0; K+                  OH-                       1.3733900526985E-1     1.47009407059955E+2  0     7.87878490588731E-4  0  0
+-B1; K+                  OH-                       3.3487971107695E-1    -2.15113077034097E+3  0    -1.71311827530218E-2  0  0
+-B2; K+                  OH-                   0  0  0  0  0  0
+-C0; K+                  OH-                        1.788662588501E-3    -2.23159846052078E+1  0    -2.02214587768356E-4  0  0
+-ALPHAS; K+                  OH-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+-B0; K+                  PO4-3                              2.4164E-1  0  0  0  0  0
+-B1; K+                  PO4-3                             5.65323E+0  0  0  0  0  0
+-B2; K+                  PO4-3                 0  0  0  0  0  0
+-C0; K+                  PO4-3                               -9.44E-3  0  0  0  0  0
+-ALPHAS; K+                  PO4-3                                 2.0E+0  0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2013a
+    # Editor: Moog
+
+-B0; K+                  Pb(SO4)2-2                         -5.349E-1  0  0  0  0  0
+-B1; K+                  Pb(SO4)2-2            0  0  0  0  0  0
+-B2; K+                  Pb(SO4)2-2            0  0  0  0  0  0
+-C0; K+                  Pb(SO4)2-2            0  0  0  0  0  0
+-ALPHAS; K+                  Pb(SO4)2-2                            2.0E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Editor: Moog
+
+-B0; K+                  PbCl3-                             -1.589E-1  0  0  0  0  0
+-B1; K+                  PbCl3-                             -9.885E-1  0  0  0  0  0
+-B2; K+                  PbCl3-                0  0  0  0  0  0
+-C0; K+                  PbCl3-                0  0  0  0  0  0
+-ALPHAS; K+                  PbCl3-                                2.0E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Editor: Moog
+
+-B0; K+                  PbCl4-2                            -2.844E-1  0  0  0  0  0
+-B1; K+                  PbCl4-2                             1.476E+0  0  0  0  0  0
+-B2; K+                  PbCl4-2               0  0  0  0  0  0
+-C0; K+                  PbCl4-2               0  0  0  0  0  0
+-ALPHAS; K+                  PbCl4-2                               2.0E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Editor: Moog
+
+-B0; K+                  SO4-2                     4.9949391296309E-2    -1.41145202357328E+4    -1.11056264285285E+2     2.90998909615732E-1    -1.26103983282218E-4  0
+-B1; K+                  SO4-2                     7.7929062667499E-1     2.56167918936797E+4      2.5260626183174E+2    -8.01713271994708E-1     4.18618165133201E-4  0
+-B2; K+                  SO4-2                 0  0  0  0  0  0
+-C0; K+                  SO4-2                    -4.8823380893737E-9     9.68608750255577E+3     7.69901240122677E+1    -2.03028031270672E-1     8.86250840820254E-5  0
+-ALPHAS; K+                  SO4-2                                 2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+-B0; K+                  U(CO3)4-4                             1.0E+0  0  0  0  0  0
+-B1; K+                  U(CO3)4-4                             1.3E+1  0  0  0  0  0
+-B2; K+                  U(CO3)4-4             0  0  0  0  0  0
+-C0; K+                  U(CO3)4-4             0  0  0  0  0  0
+-ALPHAS; K+                  U(CO3)4-4                             2.0E+0  0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Description: estimated resp. to Pitzer parameters of analogue species, Cphi and ternre parameters unknown (set to be zero); may lead to wrong activity coefficients with increasing ionic strength: parameter set is suitable only for chloride concentration <0.5 M
+    # Editor: Richter
+
+-B0; K+                  U(CO3)5-6                             1.5E+0  0  0  0  0  0
+-B1; K+                  U(CO3)5-6                            3.13E+1  0  0  0  0  0
+-B2; K+                  U(CO3)5-6             0  0  0  0  0  0
+-C0; K+                  U(CO3)5-6             0  0  0  0  0  0
+-ALPHAS; K+                  U(CO3)5-6                             2.0E+0  0
+    # Evaluation ip class: 1, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Additional reference: RAI/FEL1998
+    # Description: values taken in [NEC/FAN2001] by reason of consistency with correspondent equilibrium constants; value non-transferable to mixed carbonate/chloride solutions
+    # Editor: Richter
+
+-B0; K+                  U(OH)2(CO3)2-2        0  0  0  0  0  0
+-B1; K+                  U(OH)2(CO3)2-2                        2.0E+0  0  0  0  0  0
+-B2; K+                  U(OH)2(CO3)2-2        0  0  0  0  0  0
+-C0; K+                  U(OH)2(CO3)2-2        0  0  0  0  0  0
+-ALPHAS; K+                  U(OH)2(CO3)2-2                        2.0E+0  0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Description: estimated according to Pitzer parameters for analogue species, Cphi and ternre parameters unknown (set to be zero); may lead to wrong activity coefficients with increasing ionic strength: parameter set is suitable only for chloride concentration <0.5 M
+    # Editor: Richter
+
+-B0; K+                  UO2(OH)3-                            -2.6E-1  0  0  0  0  0
+-B1; K+                  UO2(OH)3-                             3.4E-1  0  0  0  0  0
+-B2; K+                  UO2(OH)3-             0  0  0  0  0  0
+-C0; K+                  UO2(OH)3-             0  0  0  0  0  0
+-ALPHAS; K+                  UO2(OH)3-                             2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Editor: Richter
+
+-B0; K+                  UO2(OH)4-2                            1.3E-1  0  0  0  0  0
+-B1; K+                  UO2(OH)4-2                           2.05E+0  0  0  0  0  0
+-B2; K+                  UO2(OH)4-2            0  0  0  0  0  0
+-C0; K+                  UO2(OH)4-2            0  0  0  0  0  0
+-ALPHAS; K+                  UO2(OH)4-2                            2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Editor: Richter
+
+-B0; K+                  Zn(OH)4-2                          2.3432E-1  0  0  0  0  0
+-B1; K+                  Zn(OH)4-2                          3.5995E+0  0  0  0  0  0
+-B2; K+                  Zn(OH)4-2             0  0  0  0  0  0
+-C0; K+                  Zn(OH)4-2                           1.745E-2  0  0  0  0  0
+-ALPHAS; K+                  Zn(OH)4-2                             2.0E+0  0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2022
+    # Description: cgamma in [HAG2022] = 0.00617
+    # Editor: Moog
+
+-B0; Mg(OH)+             CO3-2                 0  0  0  0  0  0
+-B1; Mg(OH)+             CO3-2                 0  0  0  0  0  0
+-B2; Mg(OH)+             CO3-2                 0  0  0  0  0  0
+-C0; Mg(OH)+             CO3-2                 0  0  0  0  0  0
+-ALPHAS; Mg(OH)+             CO3-2                 0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+-B0; Mg(OH)+             Cl-                   0  0  0  0  0  0
+-B1; Mg(OH)+             Cl-                   0  0  0  0  0  0
+-B2; Mg(OH)+             Cl-                   0  0  0  0  0  0
+-C0; Mg(OH)+             Cl-                   0  0  0  0  0  0
+-ALPHAS; Mg(OH)+             Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: PAN2019
+    # Editor: Freyer
+
+-B0; Mg(OH)+             HCO3-                 0  0  0  0  0  0
+-B1; Mg(OH)+             HCO3-                 0  0  0  0  0  0
+-B2; Mg(OH)+             HCO3-                 0  0  0  0  0  0
+-C0; Mg(OH)+             HCO3-                 0  0  0  0  0  0
+-ALPHAS; Mg(OH)+             HCO3-                 0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+-B0; Mg(OH)+             OH-                   0  0  0  0  0  0
+-B1; Mg(OH)+             OH-                   0  0  0  0  0  0
+-B2; Mg(OH)+             OH-                   0  0  0  0  0  0
+-C0; Mg(OH)+             OH-                   0  0  0  0  0  0
+-ALPHAS; Mg(OH)+             OH-                   0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+-B0; Mg3TcO(OH)5+3       Cl-                                  -7.4E-2  0  0  0  0  0
+-B1; Mg3TcO(OH)5+3       Cl-                                   4.3E+0  0  0  0  0  0
+-B2; Mg3TcO(OH)5+3       Cl-                   0  0  0  0  0  0
+-C0; Mg3TcO(OH)5+3       Cl-                                   1.5E-2  0  0  0  0  0
+-ALPHAS; Mg3TcO(OH)5+3       Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/GAO2016
+    # Editor: Kiefer
+
+-B0; Mg+2                (UO2)3(OH)7-                          2.0E-1  0  0  0  0  0
+-B1; Mg+2                (UO2)3(OH)7-                          1.6E+0  0  0  0  0  0
+-B2; Mg+2                (UO2)3(OH)7-          0  0  0  0  0  0
+-C0; Mg+2                (UO2)3(OH)7-          0  0  0  0  0  0
+-ALPHAS; Mg+2                (UO2)3(OH)7-                          2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Editor: Richter
+
+-B0; Mg+2                CO3-2                 0  0  0  0  0  0
+-B1; Mg+2                CO3-2                 0  0  0  0  0  0
+-B2; Mg+2                CO3-2                 0  0  0  0  0  0
+-C0; Mg+2                CO3-2                 0  0  0  0  0  0
+-ALPHAS; Mg+2                CO3-2                                 1.4E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+-B0; Mg+2                Cl-                       3.5234576217139E-1    -9.59490759877323E+0  0    -4.56325711588189E-4  0  0
+-B1; Mg+2                Cl-                       1.6814797738046E+0      1.2392880942931E+3  0     1.63946228155632E-2  0  0
+-B2; Mg+2                Cl-                   0  0  0  0  0  0
+-C0; Mg+2                Cl-                       5.1899397863093E-3     1.25282293222683E+1  0      2.8564736424319E-5  0  0
+-ALPHAS; Mg+2                Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+-B0; Mg+2                HCO3-                                 3.3E-2  0  0  0  0  0
+-B1; Mg+2                HCO3-                                 8.5E-1  0  0  0  0  0
+-B2; Mg+2                HCO3-                 0  0  0  0  0  0
+-C0; Mg+2                HCO3-                 0  0  0  0  0  0
+-ALPHAS; Mg+2                HCO3-                                 2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Description: 
+    # Editor: Freyer
+
+-B0; Mg+2                HSO4-                     5.1924712485288E-1    -2.31093453605148E+5    -6.54035128750977E+2     6.10276753021829E-1  0     1.34341384208311E+7
+-B1; Mg+2                HSO4-                     1.7289792050033E+0  0  0  0  0  0
+-B2; Mg+2                HSO4-                 0  0  0  0  0  0
+-C0; Mg+2                HSO4-                    -1.2029348242891E-2    -5.59921141620061E+4    -1.74811982440315E+2     1.79562327379879E-1  0     2.96496433940706E+6
+-ALPHAS; Mg+2                HSO4-                                 2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+-B0; Mg+2                NO3-                               3.1676E-1  0  0  0  0  0
+-B1; Mg+2                NO3-                              2.15589E+0  0  0  0  0  0
+-B2; Mg+2                NO3-                  0  0  0  0  0  0
+-C0; Mg+2                NO3-                              -4.0173E-3  0  0  0  0  0
+-ALPHAS; Mg+2                NO3-                                  2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MUN2024
+    # Editor: Kiefer
+
+-B0; Mg+2                OH-                   0  0  0  0  0  0
+-B1; Mg+2                OH-                   0  0  0  0  0  0
+-B2; Mg+2                OH-                   0  0  0  0  0  0
+-C0; Mg+2                OH-                   0  0  0  0  0  0
+-ALPHAS; Mg+2                OH-                   0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+-B0; Mg+2                Pb(SO4)2-2                           5.72E-1  0  0  0  0  0
+-B1; Mg+2                Pb(SO4)2-2                          1.255E+0  0  0  0  0  0
+-B2; Mg+2                Pb(SO4)2-2            0  0  0  0  0  0
+-C0; Mg+2                Pb(SO4)2-2            0  0  0  0  0  0
+-ALPHAS; Mg+2                Pb(SO4)2-2                            1.4E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Editor: Moog
+
+-B0; Mg+2                PbCl3-                              3.242E-1  0  0  0  0  0
+-B1; Mg+2                PbCl3-                              -2.03E-1  0  0  0  0  0
+-B2; Mg+2                PbCl3-                0  0  0  0  0  0
+-C0; Mg+2                PbCl3-                0  0  0  0  0  0
+-ALPHAS; Mg+2                PbCl3-                                2.0E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Editor: Moog
+
+-B0; Mg+2                PbCl4-2                             3.513E-1  0  0  0  0  0
+-B1; Mg+2                PbCl4-2                             4.702E+0  0  0  0  0  0
+-B2; Mg+2                PbCl4-2               0  0  0  0  0  0
+-C0; Mg+2                PbCl4-2                             3.452E-2  0  0  0  0  0
+-ALPHAS; Mg+2                PbCl4-2                               1.4E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Description: Original value in [HAG1999]: cgamma = 0.00863 +/- 0.0004. For THEREDA cphi = 0.03452 +/- 0.0016.
+    # Editor: Moog
+
+-B0; Mg+2                SO4-2                     2.2087967316202E-1     1.65423990618798E+5     6.58462298514643E+2    -1.15985005015335E+0     3.82707396716579E-4    -7.74819138613266E+6
+-B1; Mg+2                SO4-2                     3.3428960066281E+0     5.57775460099826E+4     3.40942736424319E+2    -9.22947899452763E-1     4.70349342955078E-4    -1.81956819652414E+6
+-B2; Mg+2                SO4-2                    -3.7249543119502E+1  0    -3.19308950508148E+3     2.19252957483914E+1    -1.91180218654158E-2  0
+-C0; Mg+2                SO4-2                     2.5000979788871E-2     2.48800055926394E+3     1.27053711828733E+1    -2.42641781706657E-2     6.93981653256359E-6     -6.7851921246016E+4
+-ALPHAS; Mg+2                SO4-2                                 1.4E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+-B0; Mg+2                UO2(OH)3-                             2.0E-1  0  0  0  0  0
+-B1; Mg+2                UO2(OH)3-                             1.6E+0  0  0  0  0  0
+-B2; Mg+2                UO2(OH)3-             0  0  0  0  0  0
+-C0; Mg+2                UO2(OH)3-             0  0  0  0  0  0
+-ALPHAS; Mg+2                UO2(OH)3-                             2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Editor: Richter
+
+-B0; MgSiO(OH)3+         Cl-                                   9.0E-2  0  0  0  0  0
+-B1; MgSiO(OH)3+         Cl-                                   3.4E-1  0  0  0  0  0
+-B2; MgSiO(OH)3+         Cl-                   0  0  0  0  0  0
+-C0; MgSiO(OH)3+         Cl-                   0  0  0  0  0  0
+-ALPHAS; MgSiO(OH)3+         Cl-                                   2.0E+0  0
+    # Evaluation ip class: 3, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Additional reference: PLY/FAN1998
+    # Editor: Miron
+
+-B0; Mg(Am(NO3)(OH)2)+2  Cl-                                   1.8E-1  0  0  0  0  0
+-B1; Mg(Am(NO3)(OH)2)+2  Cl-                                   1.6E+0  0  0  0  0  0
+-B2; Mg(Am(NO3)(OH)2)+2  Cl-                   0  0  0  0  0  0
+-C0; Mg(Am(NO3)(OH)2)+2  Cl-                   0  0  0  0  0  0
+-ALPHAS; Mg(Am(NO3)(OH)2)+2  Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Mg(Am(NO3)(OH)2)+2  NO3-                                  1.8E-1  0  0  0  0  0
+-B1; Mg(Am(NO3)(OH)2)+2  NO3-                                  1.6E+0  0  0  0  0  0
+-B2; Mg(Am(NO3)(OH)2)+2  NO3-                  0  0  0  0  0  0
+-C0; Mg(Am(NO3)(OH)2)+2  NO3-                  0  0  0  0  0  0
+-ALPHAS; Mg(Am(NO3)(OH)2)+2  NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Mg(Am(NO3)(OH))+3   Cl-                                   9.3E-1  0  0  0  0  0
+-B1; Mg(Am(NO3)(OH))+3   Cl-                                   4.3E+0  0  0  0  0  0
+-B2; Mg(Am(NO3)(OH))+3   Cl-                   0  0  0  0  0  0
+-C0; Mg(Am(NO3)(OH))+3   Cl-                   0  0  0  0  0  0
+-ALPHAS; Mg(Am(NO3)(OH))+3   Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Mg(Am(NO3)(OH))+3   NO3-                                  9.3E-1  0  0  0  0  0
+-B1; Mg(Am(NO3)(OH))+3   NO3-                                  4.3E+0  0  0  0  0  0
+-B2; Mg(Am(NO3)(OH))+3   NO3-                  0  0  0  0  0  0
+-C0; Mg(Am(NO3)(OH))+3   NO3-                  0  0  0  0  0  0
+-ALPHAS; Mg(Am(NO3)(OH))+3   NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Mg(Cm(NO3)(OH)2)+2  Cl-                                   1.8E-1  0  0  0  0  0
+-B1; Mg(Cm(NO3)(OH)2)+2  Cl-                                   1.6E+0  0  0  0  0  0
+-B2; Mg(Cm(NO3)(OH)2)+2  Cl-                   0  0  0  0  0  0
+-C0; Mg(Cm(NO3)(OH)2)+2  Cl-                   0  0  0  0  0  0
+-ALPHAS; Mg(Cm(NO3)(OH)2)+2  Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Mg(Cm(NO3)(OH)2)+2  NO3-                                  1.8E-1  0  0  0  0  0
+-B1; Mg(Cm(NO3)(OH)2)+2  NO3-                                  1.6E+0  0  0  0  0  0
+-B2; Mg(Cm(NO3)(OH)2)+2  NO3-                  0  0  0  0  0  0
+-C0; Mg(Cm(NO3)(OH)2)+2  NO3-                  0  0  0  0  0  0
+-ALPHAS; Mg(Cm(NO3)(OH)2)+2  NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Mg(Cm(NO3)(OH))+3   Cl-                                   9.3E-1  0  0  0  0  0
+-B1; Mg(Cm(NO3)(OH))+3   Cl-                                   4.3E+0  0  0  0  0  0
+-B2; Mg(Cm(NO3)(OH))+3   Cl-                   0  0  0  0  0  0
+-C0; Mg(Cm(NO3)(OH))+3   Cl-                   0  0  0  0  0  0
+-ALPHAS; Mg(Cm(NO3)(OH))+3   Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Mg(Cm(NO3)(OH))+3   NO3-                                  9.3E-1  0  0  0  0  0
+-B1; Mg(Cm(NO3)(OH))+3   NO3-                                  4.3E+0  0  0  0  0  0
+-B2; Mg(Cm(NO3)(OH))+3   NO3-                  0  0  0  0  0  0
+-C0; Mg(Cm(NO3)(OH))+3   NO3-                  0  0  0  0  0  0
+-ALPHAS; Mg(Cm(NO3)(OH))+3   NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Mg(Nd(NO3)(OH)2)+2  Cl-                                   1.8E-1  0  0  0  0  0
+-B1; Mg(Nd(NO3)(OH)2)+2  Cl-                                   1.6E+0  0  0  0  0  0
+-B2; Mg(Nd(NO3)(OH)2)+2  Cl-                   0  0  0  0  0  0
+-C0; Mg(Nd(NO3)(OH)2)+2  Cl-                   0  0  0  0  0  0
+-ALPHAS; Mg(Nd(NO3)(OH)2)+2  Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Mg(Nd(NO3)(OH)2)+2  NO3-                                  1.8E-1  0  0  0  0  0
+-B1; Mg(Nd(NO3)(OH)2)+2  NO3-                                  1.6E+0  0  0  0  0  0
+-B2; Mg(Nd(NO3)(OH)2)+2  NO3-                  0  0  0  0  0  0
+-C0; Mg(Nd(NO3)(OH)2)+2  NO3-                  0  0  0  0  0  0
+-ALPHAS; Mg(Nd(NO3)(OH)2)+2  NO3-                                  2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Mg(Nd(NO3)(OH))+3   Cl-                                   9.3E-1  0  0  0  0  0
+-B1; Mg(Nd(NO3)(OH))+3   Cl-                                   4.3E+0  0  0  0  0  0
+-B2; Mg(Nd(NO3)(OH))+3   Cl-                   0  0  0  0  0  0
+-C0; Mg(Nd(NO3)(OH))+3   Cl-                   0  0  0  0  0  0
+-ALPHAS; Mg(Nd(NO3)(OH))+3   Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Mg(Nd(NO3)(OH))+3   NO3-                                  9.3E-1  0  0  0  0  0
+-B1; Mg(Nd(NO3)(OH))+3   NO3-                                  4.3E+0  0  0  0  0  0
+-B2; Mg(Nd(NO3)(OH))+3   NO3-                  0  0  0  0  0  0
+-C0; Mg(Nd(NO3)(OH))+3   NO3-                  0  0  0  0  0  0
+-ALPHAS; Mg(Nd(NO3)(OH))+3   NO3-                                  2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Na+                 (UO2)3(OH)7-                         -2.6E-1  0  0  0  0  0
+-B1; Na+                 (UO2)3(OH)7-                          3.4E-1  0  0  0  0  0
+-B2; Na+                 (UO2)3(OH)7-          0  0  0  0  0  0
+-C0; Na+                 (UO2)3(OH)7-          0  0  0  0  0  0
+-ALPHAS; Na+                 (UO2)3(OH)7-                          2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Editor: Richter
+
+-B0; Na+                 Am(CO3)2-                            -2.4E-1  0  0  0  0  0
+-B1; Na+                 Am(CO3)2-                            2.24E-1  0  0  0  0  0
+-B2; Na+                 Am(CO3)2-             0  0  0  0  0  0
+-C0; Na+                 Am(CO3)2-                            2.84E-2  0  0  0  0  0
+-ALPHAS; Na+                 Am(CO3)2-                             2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Additional reference: FAN/KON1999
+    # Description: analogue value from: Cm(CO3)2<-> and Na<+>
+    # Editor: Marquardt
+
+-B0; Na+                 Am(CO3)3-3                           1.25E-1  0  0  0  0  0
+-B1; Na+                 Am(CO3)3-3                           4.73E+0  0  0  0  0  0
+-B2; Na+                 Am(CO3)3-3            0  0  0  0  0  0
+-C0; Na+                 Am(CO3)3-3                            7.0E-4  0  0  0  0  0
+-ALPHAS; Na+                 Am(CO3)3-3                            2.0E+0  0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Additional reference: FAN/KON1999
+    # Description: analogue value from:Cm(CO3)3<3-> and Na<+>
+    # Editor: Marquardt
+
+-B0; Na+                 Am(OH)4-              0  0  0  0  0  0
+-B1; Na+                 Am(OH)4-              0  0  0  0  0  0
+-B2; Na+                 Am(OH)4-              0  0  0  0  0  0
+-C0; Na+                 Am(OH)4-              0  0  0  0  0  0
+-ALPHAS; Na+                 Am(OH)4-                              2.0E+0  0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+-B0; Na+                 Am(SO4)2-                           -3.54E-1  0  0  0  0  0
+-B1; Na+                 Am(SO4)2-                            -4.0E-1  0  0  0  0  0
+-B2; Na+                 Am(SO4)2-             0  0  0  0  0  0
+-C0; Na+                 Am(SO4)2-                             5.1E-2  0  0  0  0  0
+-ALPHAS; Na+                 Am(SO4)2-                             2.0E+0  0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Editor: Marquardt
+
+-B0; Na+                 CO3-2                        6.9640814015E-2  0  0            -1.645319E-4  0  0
+-B1; Na+                 CO3-2                             8.54379E-1              8.37341E+5              7.58103E+3             -2.26055E+1              1.11243E-2  0
+-B2; Na+                 CO3-2                 0  0  0  0  0  0
+-C0; Na+                 CO3-2                 0  0  0  0  0  0
+-ALPHAS; Na+                 CO3-2                                 2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Description: 
+    # Editor: Freyer
+
+-B0; Na+                 Cl-                       7.5393193875357E-2            9.9310954E+3            3.7468729E+1              -6.3524E-2               2.0008E-5            -5.086633E+5
+-B1; Na+                 Cl-                       2.7632794433885E-1            2.7034783E+4             1.022781E+2             -1.71355E-1               5.4624E-5            -1.335514E+6
+-B2; Na+                 Cl-                   0  0  0  0  0  0
+-C0; Na+                 Cl-                       1.5304749340856E-3            -4.635055E+3            -1.811616E+1              3.11444E-2              -9.9052E-6            2.2164678E+5
+-ALPHAS; Na+                 Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 480.15 K.
+    # Reference: VOI2020a
+    # Editor: Freyer
+
+-B0; Na+                 Cm(CO3)2-                            -2.4E-1  0  0  0  0  0
+-B1; Na+                 Cm(CO3)2-                            2.24E-1  0  0  0  0  0
+-B2; Na+                 Cm(CO3)2-             0  0  0  0  0  0
+-C0; Na+                 Cm(CO3)2-                            2.84E-2  0  0  0  0  0
+-ALPHAS; Na+                 Cm(CO3)2-                             2.0E+0  0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FAN/KON1999
+    # Additional reference: NEC/FAN1998
+    # Editor: Marquardt
+
+-B0; Na+                 Cm(CO3)3-3                           1.25E-1  0  0  0  0  0
+-B1; Na+                 Cm(CO3)3-3                           4.73E+0  0  0  0  0  0
+-B2; Na+                 Cm(CO3)3-3            0  0  0  0  0  0
+-C0; Na+                 Cm(CO3)3-3                            7.0E-4  0  0  0  0  0
+-ALPHAS; Na+                 Cm(CO3)3-3                            2.0E+0  0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FAN/KON1999
+    # Additional reference: NEC/FAN1998
+    # Editor: Marquardt
+
+-B0; Na+                 Cm(CO3)4-5                          2.022E+0  0  0  0  0  0
+-B1; Na+                 Cm(CO3)4-5                          1.922E+1  0  0  0  0  0
+-B2; Na+                 Cm(CO3)4-5            0  0  0  0  0  0
+-C0; Na+                 Cm(CO3)4-5                          -3.05E-1  0  0  0  0  0
+-ALPHAS; Na+                 Cm(CO3)4-5                            2.0E+0  0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FAN/KON1999
+    # Additional reference: NEC/FAN1998
+    # Editor: Marquardt
+
+-B0; Na+                 Cm(SO4)2-                           -3.54E-1  0  0  0  0  0
+-B1; Na+                 Cm(SO4)2-                            -4.0E-1  0  0  0  0  0
+-B2; Na+                 Cm(SO4)2-             0  0  0  0  0  0
+-C0; Na+                 Cm(SO4)2-                             5.1E-2  0  0  0  0  0
+-ALPHAS; Na+                 Cm(SO4)2-                             2.0E+0  0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Editor: Marquardt
+
+-B0; Na+                 H2PO4-                              -4.36E-2  0  0  0  0  0
+-B1; Na+                 H2PO4-                             -3.389E-2  0  0  0  0  0
+-B2; Na+                 H2PO4-                0  0  0  0  0  0
+-C0; Na+                 H2PO4-                               6.05E-3  0  0  0  0  0
+-ALPHAS; Na+                 H2PO4-                                2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2013a
+    # Editor: Moog
+
+-B0; Na+                 HCO3-                           -9.306555E-3  0  0  0  0  0
+-B1; Na+                 HCO3-                     1.8113211484845E-1  0  0              1.80959E-2            -1.863198E-5  0
+-B2; Na+                 HCO3-                 0  0  0  0  0  0
+-C0; Na+                 HCO3-                 0  0  0  0  0  0
+-ALPHAS; Na+                 HCO3-                                 2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Description: 
+    # Editor: Freyer
+
+-B0; Na+                 HPO4-2                              -1.72E-2  0  0  0  0  0
+-B1; Na+                 HPO4-2                             1.2116E+0  0  0  0  0  0
+-B2; Na+                 HPO4-2                0  0  0  0  0  0
+-C0; Na+                 HPO4-2                               5.85E-3  0  0  0  0  0
+-ALPHAS; Na+                 HPO4-2                                2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2013a
+    # Editor: Moog
+
+-B0; Na+                 HSO4-                     1.0575811127717E-1    -4.47906777316736E+2     -5.0006267881412E+0     1.51569732395213E-2    -7.11501458897107E-6    -1.06418949798545E+1
+-B1; Na+                 HSO4-                     2.0774634253922E-2     2.82418162366949E+2      3.1531865163269E+0     1.87472178723916E-2    -2.88379593481268E-5     7.24542359492453E+0
+-B2; Na+                 HSO4-                 0  0  0  0  0  0
+-C0; Na+                 HSO4-                    -5.8343932580245E-3     9.48299032413254E+1     1.05868663467436E+0    -3.33883764507788E-3     1.61486274580552E-6       1.862581604426E+0
+-ALPHAS; Na+                 HSO4-                                 2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+-B0; Na+                 Mg(CO3)2-2                       6.964081E-2  0  0              -1.6453E-4  0  0
+-B1; Na+                 Mg(CO3)2-2                        8.54379E-1              8.37341E+5              7.58103E+3             -2.26055E+1              1.11243E-2  0
+-B2; Na+                 Mg(CO3)2-2            0  0  0  0  0  0
+-C0; Na+                 Mg(CO3)2-2            0  0  0  0  0  0
+-ALPHAS; Na+                 Mg(CO3)2-2                            2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Description: anion and interaction was generated by Knigsberger/Knigsberger 1999 and transferred into THEREDA as described in THEREDA Journal by Voigt
+    # Editor: Freyer
+
+-B0; Na+                 NO3-                                 5.34E-3  0  0  0  0  0
+-B1; Na+                 NO3-                               1.5983E-1  0  0  0  0  0
+-B2; Na+                 NO3-                  0  0  0  0  0  0
+-C0; Na+                 NO3-                                -2.54E-4  0  0  0  0  0
+-ALPHAS; Na+                 NO3-                                  2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MUN2024
+    # Editor: Kiefer
+
+-B0; Na+                 Nd(OH)4-              0  0  0  0  0  0
+-B1; Na+                 Nd(OH)4-              0  0  0  0  0  0
+-B2; Na+                 Nd(OH)4-              0  0  0  0  0  0
+-C0; Na+                 Nd(OH)4-              0  0  0  0  0  0
+-ALPHAS; Na+                 Nd(OH)4-                              2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Am(OH)4<->
+    # Editor: Marquardt
+
+-B0; Na+                 Np(CO3)5-6                            1.5E+0  0  0  0  0  0
+-B1; Na+                 Np(CO3)5-6                           3.13E+1  0  0  0  0  0
+-B2; Na+                 Np(CO3)5-6            0  0  0  0  0  0
+-C0; Na+                 Np(CO3)5-6            0  0  0  0  0  0
+-ALPHAS; Na+                 Np(CO3)5-6                            2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Additional reference: RAI/HES1999
+    # Editor: Marquardt
+
+-B0; Na+                 Np(OH)2(CO3)2-2       0  0  0  0  0  0
+-B1; Na+                 Np(OH)2(CO3)2-2                       2.0E+0  0  0  0  0  0
+-B2; Na+                 Np(OH)2(CO3)2-2       0  0  0  0  0  0
+-C0; Na+                 Np(OH)2(CO3)2-2       0  0  0  0  0  0
+-ALPHAS; Na+                 Np(OH)2(CO3)2-2                       2.0E+0  0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+-B0; Na+                 NpO2(CO3)2-3                          4.8E-1  0  0  0  0  0
+-B1; Na+                 NpO2(CO3)2-3                          4.4E+0  0  0  0  0  0
+-B2; Na+                 NpO2(CO3)2-3          0  0  0  0  0  0
+-C0; Na+                 NpO2(CO3)2-3          0  0  0  0  0  0
+-ALPHAS; Na+                 NpO2(CO3)2-3                          2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Additional reference: FAN/NEC1995
+    # Editor: Marquardt
+
+-B0; Na+                 NpO2(CO3)3-5                          1.8E+0  0  0  0  0  0
+-B1; Na+                 NpO2(CO3)3-5                         2.27E+1  0  0  0  0  0
+-B2; Na+                 NpO2(CO3)3-5          0  0  0  0  0  0
+-C0; Na+                 NpO2(CO3)3-5          0  0  0  0  0  0
+-ALPHAS; Na+                 NpO2(CO3)3-5                          2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Editor: Marquardt
+
+-B0; Na+                 NpO2(CO3)-                            1.0E-1  0  0  0  0  0
+-B1; Na+                 NpO2(CO3)-                            3.4E-1  0  0  0  0  0
+-B2; Na+                 NpO2(CO3)-            0  0  0  0  0  0
+-C0; Na+                 NpO2(CO3)-            0  0  0  0  0  0
+-ALPHAS; Na+                 NpO2(CO3)-                            2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Additional reference: FAN/NEC1995
+    # Editor: Marquardt
+
+-B0; Na+                 NpO2(OH)2-            0  0  0  0  0  0
+-B1; Na+                 NpO2(OH)2-            0  0  0  0  0  0
+-B2; Na+                 NpO2(OH)2-            0  0  0  0  0  0
+-C0; Na+                 NpO2(OH)2-            0  0  0  0  0  0
+-ALPHAS; Na+                 NpO2(OH)2-                            2.0E+0  0
+    # Evaluation ip class: 4, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FAN/NEC1995
+    # Additional reference: NEC1997
+    # Editor: Marquardt
+
+-B0; Na+                 OH-                       1.0436084822611E-1    -9.88884051957424E+1  0    -1.04785157977028E-3  0  0
+-B1; Na+                 OH-                        1.245819743129E-1    -2.06111999037825E+2  0    -1.29580588129172E-3  0  0
+-B2; Na+                 OH-                   0  0  0  0  0  0
+-C0; Na+                 OH-                       2.1542996464022E-3     1.73000562992363E+1  0     1.18266752059655E-4  0  0
+-ALPHAS; Na+                 OH-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+-B0; Na+                 PO4-3                              1.5641E-1  0  0  0  0  0
+-B1; Na+                 PO4-3                              3.9397E+0  0  0  0  0  0
+-B2; Na+                 PO4-3                 0  0  0  0  0  0
+-C0; Na+                 PO4-3                              -3.498E-2  0  0  0  0  0
+-ALPHAS; Na+                 PO4-3                                 2.0E+0  0
+    # Evaluation ip class: 1, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2013a
+    # Editor: Moog
+
+-B0; Na+                 Pb(SO4)2-2                           1.19E-2  0  0  0  0  0
+-B1; Na+                 Pb(SO4)2-2            0  0  0  0  0  0
+-B2; Na+                 Pb(SO4)2-2            0  0  0  0  0  0
+-C0; Na+                 Pb(SO4)2-2            0  0  0  0  0  0
+-ALPHAS; Na+                 Pb(SO4)2-2                            2.0E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Editor: Moog
+
+-B0; Na+                 PbCl3-                              -8.22E-2  0  0  0  0  0
+-B1; Na+                 PbCl3-                0  0  0  0  0  0
+-B2; Na+                 PbCl3-                0  0  0  0  0  0
+-C0; Na+                 PbCl3-                0  0  0  0  0  0
+-ALPHAS; Na+                 PbCl3-                                2.0E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Editor: Moog
+
+-B0; Na+                 PbCl4-2                             -6.83E-2  0  0  0  0  0
+-B1; Na+                 PbCl4-2                             2.104E+0  0  0  0  0  0
+-B2; Na+                 PbCl4-2               0  0  0  0  0  0
+-C0; Na+                 PbCl4-2               0  0  0  0  0  0
+-ALPHAS; Na+                 PbCl4-2                               2.0E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Editor: Moog
+
+-B0; Na+                 Pu(CO3)4-4                            1.0E+0  0  0  0  0  0
+-B1; Na+                 Pu(CO3)4-4                            1.3E+1  0  0  0  0  0
+-B2; Na+                 Pu(CO3)4-4            0  0  0  0  0  0
+-C0; Na+                 Pu(CO3)4-4            0  0  0  0  0  0
+-ALPHAS; Na+                 Pu(CO3)4-4                            2.0E+0  0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+-B0; Na+                 Pu(CO3)5-6                            1.5E+0  0  0  0  0  0
+-B1; Na+                 Pu(CO3)5-6                           3.13E+1  0  0  0  0  0
+-B2; Na+                 Pu(CO3)5-6            0  0  0  0  0  0
+-C0; Na+                 Pu(CO3)5-6            0  0  0  0  0  0
+-ALPHAS; Na+                 Pu(CO3)5-6                            2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Additional reference: RAI/HES1999a
+    # Editor: Marquardt
+
+-B0; Na+                 Pu(OH)2(CO3)2-2       0  0  0  0  0  0
+-B1; Na+                 Pu(OH)2(CO3)2-2                       2.0E+0  0  0  0  0  0
+-B2; Na+                 Pu(OH)2(CO3)2-2       0  0  0  0  0  0
+-C0; Na+                 Pu(OH)2(CO3)2-2       0  0  0  0  0  0
+-ALPHAS; Na+                 Pu(OH)2(CO3)2-2                       2.0E+0  0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+-B0; Na+                 SO4-2                     1.9579891046156E-2     1.05204034674364E+3     7.85532752179927E+0    -1.29646136267966E-2  0  0
+-B1; Na+                 SO4-2                     1.1129875007366E+0     -5.0431463443382E+4    -2.91106998737146E+2      4.2220582235853E-1  0  0
+-B2; Na+                 SO4-2                 0  0  0  0  0  0
+-C0; Na+                 SO4-2                     4.9699330996802E-3    -4.94281555114559E+2    -3.12028447170606E+0     4.68167669733598E-3  0  0
+-ALPHAS; Na+                 SO4-2                                 2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+-B0; Na+                 Th(CO3)5-6                           1.31E+0  0  0  0  0  0
+-B1; Na+                 Th(CO3)5-6                            3.0E+1  0  0  0  0  0
+-B2; Na+                 Th(CO3)5-6            0  0  0  0  0  0
+-C0; Na+                 Th(CO3)5-6            0  0  0  0  0  0
+-ALPHAS; Na+                 Th(CO3)5-6                            2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FEL/RAI1999
+    # Additional reference: NEC2000
+    # Editor: Marquardt
+
+-B0; Na+                 Th(OH)3(CO3)-         0  0  0  0  0  0
+-B1; Na+                 Th(OH)3(CO3)-                         2.0E-1  0  0  0  0  0
+-B2; Na+                 Th(OH)3(CO3)-         0  0  0  0  0  0
+-C0; Na+                 Th(OH)3(CO3)-         0  0  0  0  0  0
+-ALPHAS; Na+                 Th(OH)3(CO3)-                         2.0E+0  0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+-B0; Na+                 U(CO3)4-4                             1.0E+0  0  0  0  0  0
+-B1; Na+                 U(CO3)4-4                             1.3E+1  0  0  0  0  0
+-B2; Na+                 U(CO3)4-4             0  0  0  0  0  0
+-C0; Na+                 U(CO3)4-4             0  0  0  0  0  0
+-ALPHAS; Na+                 U(CO3)4-4                             2.0E+0  0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Description: estimated resp. to Pitzer parameters of analogue species, Cphi and ternre parameters unknown (set to be zero); may lead to wrong activity coefficients with increasing ionic strength: parameter set is suitable only for chloride concentration <0.5 M
+    # Editor: Richter
+
+-B0; Na+                 U(CO3)5-6                             1.5E+0  0  0  0  0  0
+-B1; Na+                 U(CO3)5-6                            3.13E+1  0  0  0  0  0
+-B2; Na+                 U(CO3)5-6             0  0  0  0  0  0
+-C0; Na+                 U(CO3)5-6             0  0  0  0  0  0
+-ALPHAS; Na+                 U(CO3)5-6                             2.0E+0  0
+    # Evaluation ip class: 1, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Additional reference: RAI/FEL1998
+    # Description: values taken in [NEC/FAN2001] by reason of consistency with correspondent equilibrium constants; value non-transferable to mixed carbonate/chloride solutions
+    # Editor: Richter
+
+-B0; Na+                 U(OH)2(CO3)2-2        0  0  0  0  0  0
+-B1; Na+                 U(OH)2(CO3)2-2                        2.0E+0  0  0  0  0  0
+-B2; Na+                 U(OH)2(CO3)2-2        0  0  0  0  0  0
+-C0; Na+                 U(OH)2(CO3)2-2        0  0  0  0  0  0
+-ALPHAS; Na+                 U(OH)2(CO3)2-2                        2.0E+0  0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Description: estimated according to Pitzer parameters for analogue species, Cphi and ternre parameters unknown (set to be zero); may lead to wrong activity coefficients with increasing ionic strength: parameter set is suitable only for chloride concentration <0.5 M
+    # Editor: Richter
+
+-B0; Na+                 UO2(CO3)2-2                          2.12E-1  0  0  0  0  0
+-B1; Na+                 UO2(CO3)2-2                           2.5E+0  0  0  0  0  0
+-B2; Na+                 UO2(CO3)2-2           0  0  0  0  0  0
+-C0; Na+                 UO2(CO3)2-2           0  0  0  0  0  0
+-ALPHAS; Na+                 UO2(CO3)2-2                           2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Additional reference: PAS/CZE1997
+    # Editor: Richter
+
+-B0; Na+                 UO2(CO3)3-4                          1.25E+0  0  0  0  0  0
+-B1; Na+                 UO2(CO3)3-4                          1.16E+1  0  0  0  0  0
+-B2; Na+                 UO2(CO3)3-4           0  0  0  0  0  0
+-C0; Na+                 UO2(CO3)3-4           0  0  0  0  0  0
+-ALPHAS; Na+                 UO2(CO3)3-4                           2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Additional reference: PAS/CZE1997
+    # Editor: Richter
+
+-B0; Na+                 UO2(OH)3-                            -2.6E-1  0  0  0  0  0
+-B1; Na+                 UO2(OH)3-                             3.4E-1  0  0  0  0  0
+-B2; Na+                 UO2(OH)3-             0  0  0  0  0  0
+-C0; Na+                 UO2(OH)3-             0  0  0  0  0  0
+-ALPHAS; Na+                 UO2(OH)3-                             2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Editor: Richter
+
+-B0; Na+                 UO2(OH)4-2                            6.0E-2  0  0  0  0  0
+-B1; Na+                 UO2(OH)4-2                           1.98E+0  0  0  0  0  0
+-B2; Na+                 UO2(OH)4-2            0  0  0  0  0  0
+-C0; Na+                 UO2(OH)4-2            0  0  0  0  0  0
+-ALPHAS; Na+                 UO2(OH)4-2                            2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Editor: Richter
+
+-B0; Na+                 UO2(SO4)2-2                           3.0E-1  0  0  0  0  0
+-B1; Na+                 UO2(SO4)2-2                           1.9E+0  0  0  0  0  0
+-B2; Na+                 UO2(SO4)2-2           0  0  0  0  0  0
+-C0; Na+                 UO2(SO4)2-2           0  0  0  0  0  0
+-ALPHAS; Na+                 UO2(SO4)2-2                           2.0E+0  0
+    # Evaluation ip class: 3, data quality: 4
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: PLY/FAN1998
+    # Description: estimation of binary Pitzer parameters based on semi-empirical correlation of SIT coefficient epsilon and Pitzer parameters beta0 and beta1, IS<4M, valid only  in NaClO4 solution!
+    # Editor: Richter
+
+-B0; Na+                 Zn(OH)4-2                           2.932E-1  0  0  0  0  0
+-B1; Na+                 Zn(OH)4-2                         1.94105E+0  0  0  0  0  0
+-B2; Na+                 Zn(OH)4-2             0  0  0  0  0  0
+-C0; Na+                 Zn(OH)4-2                           -9.53E-3  0  0  0  0  0
+-ALPHAS; Na+                 Zn(OH)4-2                             2.0E+0  0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2022
+    # Description: cgamma in [HAG2022] = -0.00337
+    # Editor: Moog
+
+-B0; Nd(NO3)2+           Cl-                                   2.5E-1  0  0  0  0  0
+-B1; Nd(NO3)2+           Cl-                                   3.2E-1  0  0  0  0  0
+-B2; Nd(NO3)2+           Cl-                   0  0  0  0  0  0
+-C0; Nd(NO3)2+           Cl-                                   1.0E-1  0  0  0  0  0
+-ALPHAS; Nd(NO3)2+           Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Nd(NO3)2+           NO3-                                 4.16E-1  0  0  0  0  0
+-B1; Nd(NO3)2+           NO3-                                 4.49E-1  0  0  0  0  0
+-B2; Nd(NO3)2+           NO3-                  0  0  0  0  0  0
+-C0; Nd(NO3)2+           NO3-                  0  0  0  0  0  0
+-ALPHAS; Nd(NO3)2+           NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+-B0; Nd(NO3)+2           Cl-                                   4.2E-1  0  0  0  0  0
+-B1; Nd(NO3)+2           Cl-                                  1.83E+0  0  0  0  0  0
+-B2; Nd(NO3)+2           Cl-                   0  0  0  0  0  0
+-C0; Nd(NO3)+2           Cl-                                   5.0E-2  0  0  0  0  0
+-ALPHAS; Nd(NO3)+2           Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Nd(NO3)+2           NO3-                                 3.66E-1  0  0  0  0  0
+-B1; Nd(NO3)+2           NO3-                                1.704E+0  0  0  0  0  0
+-B2; Nd(NO3)+2           NO3-                  0  0  0  0  0  0
+-C0; Nd(NO3)+2           NO3-                  0  0  0  0  0  0
+-ALPHAS; Nd(NO3)+2           NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+-B0; Nd(OH)2+            Cl-                                  -1.3E-1  0  0  0  0  0
+-B1; Nd(OH)2+            Cl-                   0  0  0  0  0  0
+-B2; Nd(OH)2+            Cl-                   0  0  0  0  0  0
+-C0; Nd(OH)2+            Cl-                   0  0  0  0  0  0
+-ALPHAS; Nd(OH)2+            Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: value from TRLFS Cm data
+    # Editor: Marquardt
+
+-B0; Nd(OH)2+            NO3-                                 -1.3E-1  0  0  0  0  0
+-B1; Nd(OH)2+            NO3-                  0  0  0  0  0  0
+-B2; Nd(OH)2+            NO3-                  0  0  0  0  0  0
+-C0; Nd(OH)2+            NO3-                  0  0  0  0  0  0
+-ALPHAS; Nd(OH)2+            NO3-                                  2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Ca+2                Nd(OH)4-              0  0  0  0  0  0
+-B1; Ca+2                Nd(OH)4-              0  0  0  0  0  0
+-B2; Ca+2                Nd(OH)4-              0  0  0  0  0  0
+-C0; Ca+2                Nd(OH)4-              0  0  0  0  0  0
+-ALPHAS; Ca+2                Nd(OH)4-                              2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Am(OH)4<-> interaction
+    # Editor: Marquardt
+
+-B0; K+                  Nd(OH)4-              0  0  0  0  0  0
+-B1; K+                  Nd(OH)4-              0  0  0  0  0  0
+-B2; K+                  Nd(OH)4-              0  0  0  0  0  0
+-C0; K+                  Nd(OH)4-              0  0  0  0  0  0
+-ALPHAS; K+                  Nd(OH)4-                              2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Am(OH)4<-> interaction with Na<+>
+    # Editor: Marquardt
+
+-B0; Mg+2                Nd(OH)4-              0  0  0  0  0  0
+-B1; Mg+2                Nd(OH)4-              0  0  0  0  0  0
+-B2; Mg+2                Nd(OH)4-              0  0  0  0  0  0
+-C0; Mg+2                Nd(OH)4-              0  0  0  0  0  0
+-ALPHAS; Mg+2                Nd(OH)4-                              2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Am(OH)4<-> interaction with Ca<2+>
+    # Editor: Marquardt
+
+-B0; Nd(OH)+2            Cl-                                   5.5E-2  0  0  0  0  0
+-B1; Nd(OH)+2            Cl-                                  1.81E+0  0  0  0  0  0
+-B2; Nd(OH)+2            Cl-                   0  0  0  0  0  0
+-C0; Nd(OH)+2            Cl-                   0  0  0  0  0  0
+-ALPHAS; Nd(OH)+2            Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Cm(OH)<2+> and Am(OH)<2+>
+    # Editor: Marquardt
+
+-B0; Nd(OH)+2            NO3-                                  5.5E-2  0  0  0  0  0
+-B1; Nd(OH)+2            NO3-                                 1.81E+0  0  0  0  0  0
+-B2; Nd(OH)+2            NO3-                  0  0  0  0  0  0
+-C0; Nd(OH)+2            NO3-                  0  0  0  0  0  0
+-ALPHAS; Nd(OH)+2            NO3-                                  2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; Nd+3                Cl-                                 5.856E-1  0  0  0  0  0
+-B1; Nd+3                Cl-                                   5.6E+0  0  0  0  0  0
+-B2; Nd+3                Cl-                   0  0  0  0  0  0
+-C0; Nd+3                Cl-                                  -1.6E-2  0  0  0  0  0
+-ALPHAS; Nd+3                Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Editor: Marquardt
+
+-B0; Nd+3                NO3-                                 5.93E-1  0  0  0  0  0
+-B1; Nd+3                NO3-                                  5.6E+0  0  0  0  0  0
+-B2; Nd+3                NO3-                  0  0  0  0  0  0
+-C0; Nd+3                NO3-                  0  0  0  0  0  0
+-ALPHAS; Nd+3                NO3-                                  2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+-B0; Nd+3                SO4-2                               1.792E+0  0  0  0  0  0
+-B1; Nd+3                SO4-2                              1.5044E+1  0  0  0  0  0
+-B2; Nd+3                SO4-2                 0  0  0  0  0  0
+-C0; Nd+3                SO4-2                                -6.0E-1  0  0  0  0  0
+-ALPHAS; Nd+3                SO4-2                                 2.0E+0  0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Additional reference: RAR1996
+    # Description: calculated from isopetic data of Lu2(SO4)3 von RAR1996
+    # Editor: Marquardt
+
+-B0; NdCl2+              Cl-                                  5.16E-1  0  0  0  0  0
+-B1; NdCl2+              Cl-                                  1.75E+0  0  0  0  0  0
+-B2; NdCl2+              Cl-                   0  0  0  0  0  0
+-C0; NdCl2+              Cl-                                   1.0E-2  0  0  0  0  0
+-ALPHAS; NdCl2+              Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: CmCl2<+>. Cm(III)-data from KON/FAN1997
+    # Editor: Marquardt
+
+-B0; NdCl2+              NO3-                                 5.16E-1  0  0  0  0  0
+-B1; NdCl2+              NO3-                                 1.75E+0  0  0  0  0  0
+-B2; NdCl2+              NO3-                  0  0  0  0  0  0
+-C0; NdCl2+              NO3-                                  1.0E-2  0  0  0  0  0
+-ALPHAS; NdCl2+              NO3-                                  2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; NdCl+2              Cl-                                  5.93E-1  0  0  0  0  0
+-B1; NdCl+2              Cl-                                  3.15E+0  0  0  0  0  0
+-B2; NdCl+2              Cl-                   0  0  0  0  0  0
+-C0; NdCl+2              Cl-                                  -6.0E-3  0  0  0  0  0
+-ALPHAS; NdCl+2              Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: CmCl<2+> and CmCl<2+>
+    # Editor: Marquardt
+
+-B0; NdCl+2              NO3-                                 5.93E-1  0  0  0  0  0
+-B1; NdCl+2              NO3-                                 3.15E+0  0  0  0  0  0
+-B2; NdCl+2              NO3-                  0  0  0  0  0  0
+-C0; NdCl+2              NO3-                                 -6.0E-3  0  0  0  0  0
+-ALPHAS; NdCl+2              NO3-                                  2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+-B0; K+                  Np(CO3)5-6                            1.5E+0  0  0  0  0  0
+-B1; K+                  Np(CO3)5-6                           3.13E+1  0  0  0  0  0
+-B2; K+                  Np(CO3)5-6            0  0  0  0  0  0
+-C0; K+                  Np(CO3)5-6            0  0  0  0  0  0
+-ALPHAS; K+                  Np(CO3)5-6                            2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Additional reference: RAI/HES1999
+    # Editor: Marquardt
+
+-B0; K+                  Np(OH)2(CO3)2-2       0  0  0  0  0  0
+-B1; K+                  Np(OH)2(CO3)2-2                       2.0E+0  0  0  0  0  0
+-B2; K+                  Np(OH)2(CO3)2-2       0  0  0  0  0  0
+-C0; K+                  Np(OH)2(CO3)2-2       0  0  0  0  0  0
+-ALPHAS; K+                  Np(OH)2(CO3)2-2                       2.0E+0  0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+-B0; Np(OH)2+2           Cl-                                   2.3E-1  0  0  0  0  0
+-B1; Np(OH)2+2           Cl-                                   1.9E+0  0  0  0  0  0
+-B2; Np(OH)2+2           Cl-                   0  0  0  0  0  0
+-C0; Np(OH)2+2           Cl-                   0  0  0  0  0  0
+-ALPHAS; Np(OH)2+2           Cl-                                   2.0E+0  0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+-B0; Np(OH)3+            Cl-                                   1.0E-1  0  0  0  0  0
+-B1; Np(OH)3+            Cl-                                   4.0E-1  0  0  0  0  0
+-B2; Np(OH)3+            Cl-                   0  0  0  0  0  0
+-C0; Np(OH)3+            Cl-                   0  0  0  0  0  0
+-ALPHAS; Np(OH)3+            Cl-                                   2.0E+0  0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+-B0; Np(OH)+3            Cl-                                   6.0E-1  0  0  0  0  0
+-B1; Np(OH)+3            Cl-                                   5.9E+0  0  0  0  0  0
+-B2; Np(OH)+3            Cl-                   0  0  0  0  0  0
+-C0; Np(OH)+3            Cl-                   0  0  0  0  0  0
+-ALPHAS; Np(OH)+3            Cl-                                   2.0E+0  0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+-B0; Np+4                Cl-                                  1.32E+0  0  0  0  0  0
+-B1; Np+4                Cl-                                  1.35E+1  0  0  0  0  0
+-B2; Np+4                Cl-                   0  0  0  0  0  0
+-C0; Np+4                Cl-                   0  0  0  0  0  0
+-ALPHAS; Np+4                Cl-                                   2.0E+0  0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+-B0; K+                  NpO2(CO3)2-3                          4.8E-1  0  0  0  0  0
+-B1; K+                  NpO2(CO3)2-3                          4.4E+0  0  0  0  0  0
+-B2; K+                  NpO2(CO3)2-3          0  0  0  0  0  0
+-C0; K+                  NpO2(CO3)2-3          0  0  0  0  0  0
+-ALPHAS; K+                  NpO2(CO3)2-3                          2.0E+0  0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Description: estimated based on analogies of charge and ionic radius
+    # Editor: Marquardt
+
+-B0; Mg+2                NpO2(CO3)2-3          0  0  0  0  0  0
+-B1; Mg+2                NpO2(CO3)2-3          0  0  0  0  0  0
+-B2; Mg+2                NpO2(CO3)2-3          0  0  0  0  0  0
+-C0; Mg+2                NpO2(CO3)2-3          0  0  0  0  0  0
+-ALPHAS; Mg+2                NpO2(CO3)2-3          0  0
+    # Evaluation ip class: 4, data quality: 4
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: ALT/BRE2004
+    # Description: Pitzer interactions parameter can be neglected. The species is not relevant in MgCl2 solutions, because formation and precipitation of Brucit controls low carbonate concentrations.
+    # Editor: Marquardt
+
+-B0; K+                  NpO2(CO3)3-5                          1.8E+0  0  0  0  0  0
+-B1; K+                  NpO2(CO3)3-5                         2.27E+1  0  0  0  0  0
+-B2; K+                  NpO2(CO3)3-5          0  0  0  0  0  0
+-C0; K+                  NpO2(CO3)3-5          0  0  0  0  0  0
+-ALPHAS; K+                  NpO2(CO3)3-5                          2.0E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Editor: Marquardt
+
+-B0; Mg+2                NpO2(CO3)3-5          0  0  0  0  0  0
+-B1; Mg+2                NpO2(CO3)3-5          0  0  0  0  0  0
+-B2; Mg+2                NpO2(CO3)3-5          0  0  0  0  0  0
+-C0; Mg+2                NpO2(CO3)3-5          0  0  0  0  0  0
+-ALPHAS; Mg+2                NpO2(CO3)3-5          0  0
+    # Evaluation ip class: 4, data quality: 4
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: ALT/BRE2004
+    # Description: Pitzer interactions parameter can be neglected. The species is not relevant in MgCl2 solutions, because formation and precipitation of Brucit controls low carbonate concentrations.
+    # Editor: Marquardt
+
+-B0; K+                  NpO2(CO3)-                            1.0E-1  0  0  0  0  0
+-B1; K+                  NpO2(CO3)-                            3.4E-1  0  0  0  0  0
+-B2; K+                  NpO2(CO3)-            0  0  0  0  0  0
+-C0; K+                  NpO2(CO3)-            0  0  0  0  0  0
+-ALPHAS; K+                  NpO2(CO3)-                            2.0E+0  0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: ALT/BRE2004
+    # Additional reference: NEC1997
+    # Editor: Marquardt
+
+-B0; Mg+2                NpO2(CO3)-                            4.0E-1  0  0  0  0  0
+-B1; Mg+2                NpO2(CO3)-                            1.7E+0  0  0  0  0  0
+-B2; Mg+2                NpO2(CO3)-            0  0  0  0  0  0
+-C0; Mg+2                NpO2(CO3)-            0  0  0  0  0  0
+-ALPHAS; Mg+2                NpO2(CO3)-                            2.0E+0  0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: ALT/BRE2004
+    # Additional reference: NEC1997
+    # Editor: Marquardt
+
+-B0; K+                  NpO2(OH)2-            0  0  0  0  0  0
+-B1; K+                  NpO2(OH)2-            0  0  0  0  0  0
+-B2; K+                  NpO2(OH)2-            0  0  0  0  0  0
+-C0; K+                  NpO2(OH)2-            0  0  0  0  0  0
+-ALPHAS; K+                  NpO2(OH)2-                            2.0E+0  0
+    # Evaluation ip class: 4, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Description: Pitzer parameter are set to be zero!
+    # Editor: Marquardt
+
+-B0; NpO2+               Cl-                                 1.415E-1  0  0  0  0  0
+-B1; NpO2+               Cl-                                  2.81E-1  0  0  0  0  0
+-B2; NpO2+               Cl-                   0  0  0  0  0  0
+-C0; NpO2+               Cl-                   0  0  0  0  0  0
+-ALPHAS; NpO2+               Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Additional reference: FAN/NEC1995
+    # Editor: Marquardt
+
+-B0; K+                  Pb(OH)3-                           2.5725E-1  0  0  0  0  0
+-B1; K+                  Pb(OH)3-              0  0  0  0  0  0
+-B2; K+                  Pb(OH)3-              0  0  0  0  0  0
+-C0; K+                  Pb(OH)3-                             4.28E-3  0  0  0  0  0
+-ALPHAS; K+                  Pb(OH)3-                              2.0E+0  0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2022
+    # Description: Original value in [HAG1999]: cgamma = 0.00214. For THEREDA cphi = 0.00428.
+    # Editor: Moog
+
+-B0; Na+                 Pb(OH)3-                           2.0538E-1  0  0  0  0  0
+-B1; Na+                 Pb(OH)3-              0  0  0  0  0  0
+-B2; Na+                 Pb(OH)3-              0  0  0  0  0  0
+-C0; Na+                 Pb(OH)3-                           -1.326E-2  0  0  0  0  0
+-ALPHAS; Na+                 Pb(OH)3-                              2.0E+0  0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2022
+    # Description: Original value in [HAG1999]: cgamma = -0.00663. For THEREDA cphi = -0.01326.
+    # Editor: Moog
+
+-B0; Pb+2                Cl-                                 3.159E-1  0  0  0  0  0
+-B1; Pb+2                Cl-                                1.6141E+0  0  0  0  0  0
+-B2; Pb+2                Cl-                   0  0  0  0  0  0
+-C0; Pb+2                Cl-                              -3.39411E-4  0  0  0  0  0
+-ALPHAS; Pb+2                Cl-                                   2.0E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Editor: Moog
+
+-B0; Pb+2                SO4-2                                 2.0E-1  0  0  0  0  0
+-B1; Pb+2                SO4-2                              3.1973E+0  0  0  0  0  0
+-B2; Pb+2                SO4-2                 0  0  0  0  0  0
+-C0; Pb+2                SO4-2                 0  0  0  0  0  0
+-ALPHAS; Pb+2                SO4-2                                 1.4E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Description: adopted from [1984HAR/MOL] for CaSO4
+    # Editor: Moog
+
+-B0; PbCl+               Cl-                                 3.008E-1  0  0  0  0  0
+-B1; PbCl+               Cl-                                -9.916E-1  0  0  0  0  0
+-B2; PbCl+               Cl-                   0  0  0  0  0  0
+-C0; PbCl+               Cl-                   0  0  0  0  0  0
+-ALPHAS; PbCl+               Cl-                                   2.0E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Editor: Moog
+
+-B0; PbCl+               SO4-2                               -1.02E-2  0  0  0  0  0
+-B1; PbCl+               SO4-2                               -6.29E+0  0  0  0  0  0
+-B2; PbCl+               SO4-2                 0  0  0  0  0  0
+-C0; PbCl+               SO4-2                 0  0  0  0  0  0
+-ALPHAS; PbCl+               SO4-2                                 2.0E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Editor: Moog
+
+-B0; K+                  Pu(CO3)4-4                            1.0E+0  0  0  0  0  0
+-B1; K+                  Pu(CO3)4-4                            1.3E+1  0  0  0  0  0
+-B2; K+                  Pu(CO3)4-4            0  0  0  0  0  0
+-C0; K+                  Pu(CO3)4-4            0  0  0  0  0  0
+-ALPHAS; K+                  Pu(CO3)4-4                            2.0E+0  0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+-B0; K+                  Pu(CO3)5-6                            1.5E+0  0  0  0  0  0
+-B1; K+                  Pu(CO3)5-6                           3.13E+1  0  0  0  0  0
+-B2; K+                  Pu(CO3)5-6            0  0  0  0  0  0
+-C0; K+                  Pu(CO3)5-6            0  0  0  0  0  0
+-ALPHAS; K+                  Pu(CO3)5-6                            2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Additional reference: RAI/HES1999a
+    # Editor: Marquardt
+
+-B0; K+                  Pu(OH)2(CO3)2-2       0  0  0  0  0  0
+-B1; K+                  Pu(OH)2(CO3)2-2                       2.0E+0  0  0  0  0  0
+-B2; K+                  Pu(OH)2(CO3)2-2       0  0  0  0  0  0
+-C0; K+                  Pu(OH)2(CO3)2-2       0  0  0  0  0  0
+-ALPHAS; K+                  Pu(OH)2(CO3)2-2                       2.0E+0  0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+-B0; Pu(OH)2+2           Cl-                                   2.3E-1  0  0  0  0  0
+-B1; Pu(OH)2+2           Cl-                                   1.9E+0  0  0  0  0  0
+-B2; Pu(OH)2+2           Cl-                   0  0  0  0  0  0
+-C0; Pu(OH)2+2           Cl-                   0  0  0  0  0  0
+-ALPHAS; Pu(OH)2+2           Cl-                                   2.0E+0  0
+    # Evaluation ip class: 3, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MAR/GAO2014
+    # Additional reference: ALT/BRE2004
+    # Editor: Marquardt
+
+-B0; Pu(OH)3+            Cl-                                   8.0E-2  0  0  0  0  0
+-B1; Pu(OH)3+            Cl-                                   3.9E-1  0  0  0  0  0
+-B2; Pu(OH)3+            Cl-                   0  0  0  0  0  0
+-C0; Pu(OH)3+            Cl-                   0  0  0  0  0  0
+-ALPHAS; Pu(OH)3+            Cl-                                   2.0E+0  0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+-B0; Pu(OH)+3            Cl-                                   6.0E-1  0  0  0  0  0
+-B1; Pu(OH)+3            Cl-                                   5.9E+0  0  0  0  0  0
+-B2; Pu(OH)+3            Cl-                   0  0  0  0  0  0
+-C0; Pu(OH)+3            Cl-                   0  0  0  0  0  0
+-ALPHAS; Pu(OH)+3            Cl-                                   2.0E+0  0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+-B0; Pu+4                Cl-                                  1.32E+0  0  0  0  0  0
+-B1; Pu+4                Cl-                                  1.35E+1  0  0  0  0  0
+-B2; Pu+4                Cl-                   0  0  0  0  0  0
+-C0; Pu+4                Cl-                   0  0  0  0  0  0
+-ALPHAS; Pu+4                Cl-                                   2.0E+0  0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+-B0; K+                  SeO3-2                              2.092E-1  0  0  0  0  0
+-B1; K+                  SeO3-2                             1.9927E+0  0  0  0  0  0
+-B2; K+                  SeO3-2                0  0  0  0  0  0
+-C0; K+                  SeO3-2                          -8.580317E-3  0  0  0  0  0
+-ALPHAS; K+                  SeO3-2                                2.0E+0  0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 363.15 K.
+    # Reference: BIS/HAG2016
+    # Description: C calculated from C, temperature function parameters tested between 40 and 90 C, not tested for 25 C
+    # Editor: Bok
+
+-B0; Na+                 SeO3-2                              9.196E-2  0  0              5.33821E-4  0  0
+-B1; Na+                 SeO3-2                            1.60028E+0  0  0              1.80793E-2  0  0
+-B2; Na+                 SeO3-2                0  0  0  0  0  0
+-C0; Na+                 SeO3-2                           3.337544E-3  0  0             -1.24498E-4  0  0
+-ALPHAS; Na+                 SeO3-2                                2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: BIS/HAG2016
+    # Description: C calculated from C
+    # Editor: Bok
+
+-B0; Ca+2                SeO4-2                             3.2761E-1  0  0             -5.89244E-4  0  0
+-B1; Ca+2                SeO4-2                            3.90403E+0  0  0             -3.70423E-4  0  0
+-B2; Ca+2                SeO4-2                0  0  0  0  0  0
+-C0; Ca+2                SeO4-2                               8.96E-3  0  0  0  0  0
+-ALPHAS; Ca+2                SeO4-2                                1.4E+0  0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: BIS/HAG2016
+    # Description: BIS/HAG2016: MgSeO4 ion interaction coefficients  were also applied to CaSeO4 solutions.  In BIS/HAG2016 no value for beta-2 was given for the interaction Mg+2 - SeO4-2, but after personal communication we know its been 0.0. C calculated from C
+    # Editor: Bok
+
+-B0; K+                  SeO4-2                              9.481E-2  0  0              4.03623E-4  0  0
+-B1; K+                  SeO4-2                            1.62335E+0  0  0              7.41599E-3  0  0
+-B2; K+                  SeO4-2                0  0  0  0  0  0
+-C0; K+                  SeO4-2                             5.9397E-4  0  0             -8.46862E-5  0  0
+-ALPHAS; K+                  SeO4-2                                2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: BIS/HAG2016
+    # Description: C calculated from C
+    # Editor: Bok
+
+-B0; Mg+2                SeO4-2                             3.2761E-1  0  0             -5.89244E-4  0  0
+-B1; Mg+2                SeO4-2                            3.90403E+0  0  0             -3.70423E-4  0  0
+-B2; Mg+2                SeO4-2                0  0  0  0  0  0
+-C0; Mg+2                SeO4-2                               8.96E-3  0  0  0  0  0
+-ALPHAS; Mg+2                SeO4-2                                1.4E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: BIS/HAG2016
+    # Description: C calculated from C
+    # Editor: Bok
+
+-B0; Na+                 SeO4-2                              9.771E-2  0  0             -2.55183E-5  0  0
+-B1; Na+                 SeO4-2                             7.8265E-1  0  0              3.60869E-2  0  0
+-B2; Na+                 SeO4-2                0  0  0  0  0  0
+-C0; Na+                 SeO4-2                0  0  0  0  0  0
+-ALPHAS; Na+                 SeO4-2                                2.0E+0  0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: BIS/HAG2016
+    # Description: C calculated from C
+    # Editor: Bok
+
+-B0; K+                  Si4O8(OH)4-4          0  0  0  0  0  0
+-B1; K+                  Si4O8(OH)4-4          0  0  0  0  0  0
+-B2; K+                  Si4O8(OH)4-4          0  0  0  0  0  0
+-C0; K+                  Si4O8(OH)4-4          0  0  0  0  0  0
+-ALPHAS; K+                  Si4O8(OH)4-4          0  0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+-B0; Na+                 Si4O8(OH)4-4                         1.35E+0  0  0  0  0  0
+-B1; Na+                 Si4O8(OH)4-4                          1.1E+1  0  0  0  0  0
+-B2; Na+                 Si4O8(OH)4-4          0  0  0  0  0  0
+-C0; Na+                 Si4O8(OH)4-4          0  0  0  0  0  0
+-ALPHAS; Na+                 Si4O8(OH)4-4                          2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+-B0; Ca+2                SiO(OH)3-             0  0  0  0  0  0
+-B1; Ca+2                SiO(OH)3-             0  0  0  0  0  0
+-B2; Ca+2                SiO(OH)3-             0  0  0  0  0  0
+-C0; Ca+2                SiO(OH)3-             0  0  0  0  0  0
+-ALPHAS; Ca+2                SiO(OH)3-                             2.0E+0  0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+-B0; H+                  SiO(OH)3-             0  0  0  0  0  0
+-B1; H+                  SiO(OH)3-             0  0  0  0  0  0
+-B2; H+                  SiO(OH)3-             0  0  0  0  0  0
+-C0; H+                  SiO(OH)3-             0  0  0  0  0  0
+-ALPHAS; H+                  SiO(OH)3-                             2.0E+0  0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+-B0; K+                  SiO(OH)3-                            2.96E-2                  5.0E+1  0  0  0  0
+-B1; K+                  SiO(OH)3-                            -1.3E-2                  5.0E+1  0  0  0  0
+-B2; K+                  SiO(OH)3-             0  0  0  0  0  0
+-C0; K+                  SiO(OH)3-                            -2.0E-3                 -3.3E+1  0  0  0  0
+-ALPHAS; K+                  SiO(OH)3-                             2.0E+0  0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 323.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+-B0; Mg+2                SiO(OH)3-             0  0  0  0  0  0
+-B1; Mg+2                SiO(OH)3-             0  0  0  0  0  0
+-B2; Mg+2                SiO(OH)3-             0  0  0  0  0  0
+-C0; Mg+2                SiO(OH)3-             0  0  0  0  0  0
+-ALPHAS; Mg+2                SiO(OH)3-                             2.0E+0  0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+-B0; Na+                 SiO(OH)3-                            2.77E-2                  5.0E+1  0  0  0  0
+-B1; Na+                 SiO(OH)3-                            4.11E-2                  5.0E+1  0  0  0  0
+-B2; Na+                 SiO(OH)3-             0  0  0  0  0  0
+-C0; Na+                 SiO(OH)3-                             6.0E-3                 -3.3E+1  0  0  0  0
+-ALPHAS; Na+                 SiO(OH)3-                             2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 573.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+-B0; Ca+2                SiO2(OH)2-2           0  0  0  0  0  0
+-B1; Ca+2                SiO2(OH)2-2           0  0  0  0  0  0
+-B2; Ca+2                SiO2(OH)2-2           0  0  0  0  0  0
+-C0; Ca+2                SiO2(OH)2-2           0  0  0  0  0  0
+-ALPHAS; Ca+2                SiO2(OH)2-2                           1.4E+0                  1.2E+1
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+-B0; H+                  SiO2(OH)2-2           0  0  0  0  0  0
+-B1; H+                  SiO2(OH)2-2           0  0  0  0  0  0
+-B2; H+                  SiO2(OH)2-2           0  0  0  0  0  0
+-C0; H+                  SiO2(OH)2-2           0  0  0  0  0  0
+-ALPHAS; H+                  SiO2(OH)2-2                           2.0E+0  0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Description: 
+    # Editor: Miron
+
+-B0; K+                  SiO2(OH)2-2                          1.61E-1  0  0  0  0  0
+-B1; K+                  SiO2(OH)2-2                         1.591E+0  0  0  0  0  0
+-B2; K+                  SiO2(OH)2-2           0  0  0  0  0  0
+-C0; K+                  SiO2(OH)2-2                          -1.5E-3  0  0  0  0  0
+-ALPHAS; K+                  SiO2(OH)2-2                           2.0E+0  0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+-B0; Mg+2                SiO2(OH)2-2           0  0  0  0  0  0
+-B1; Mg+2                SiO2(OH)2-2           0  0  0  0  0  0
+-B2; Mg+2                SiO2(OH)2-2           0  0  0  0  0  0
+-C0; Mg+2                SiO2(OH)2-2           0  0  0  0  0  0
+-ALPHAS; Mg+2                SiO2(OH)2-2                           1.4E+0                  1.2E+1
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+-B0; Na+                 SiO2(OH)2-2                           5.2E-2  0  0  0  0  0
+-B1; Na+                 SiO2(OH)2-2                          1.55E+0  0  0  0  0  0
+-B2; Na+                 SiO2(OH)2-2           0  0  0  0  0  0
+-C0; Na+                 SiO2(OH)2-2                           4.4E-3  0  0  0  0  0
+-ALPHAS; Na+                 SiO2(OH)2-2                           2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 323.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+-B0; Sr+2                Cl-                               2.82054E-1  0  0  0  0  0
+-B1; Sr+2                Cl-                               1.44967E+0  0  0  0  0  0
+-B2; Sr+2                Cl-                   0  0  0  0  0  0
+-C0; Sr+2                Cl-                                 -5.52E-4  0  0  0  0  0
+-ALPHAS; Sr+2                Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH2016
+    # Editor: Moog
+
+-B0; Sr+2                SO4-2                                 2.0E-1  0  0  0  0  0
+-B1; Sr+2                SO4-2                             1.30949E+0  0  0  0  0  0
+-B2; Sr+2                SO4-2                              -2.431E+1  0  0  0  0  0
+-C0; Sr+2                SO4-2                 0  0  0  0  0  0
+-ALPHAS; Sr+2                SO4-2                                 1.4E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH2016
+    # Description: For beta(0) the value from the system CaSO4-H2O is adopte. The coefficient C(phi) is set to zero.
+    # Editor: Moog
+
+-B0; Tc2O3+2             Cl-                                -3.681E-1  0  0  0  0  0
+-B1; Tc2O3+2             Cl-                                2.6972E+0  0  0  0  0  0
+-B2; Tc2O3+2             Cl-                   0  0  0  0  0  0
+-C0; Tc2O3+2             Cl-                                   6.3E-3  0  0  0  0  0
+-ALPHAS; Tc2O3+2             Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: KIE/FEL2025
+    # Additional reference: YAL/GAO2016
+    # Editor: Kiefer
+
+-B0; Ca+2                TcO(OH)3-                             3.0E-1  0  0  0  0  0
+-B1; Ca+2                TcO(OH)3-                             1.7E+0  0  0  0  0  0
+-B2; Ca+2                TcO(OH)3-             0  0  0  0  0  0
+-C0; Ca+2                TcO(OH)3-             0  0  0  0  0  0
+-ALPHAS; Ca+2                TcO(OH)3-                             2.0E+0  0
+    # Evaluation ip class: 3, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/GAO2016
+    # Editor: Kiefer
+
+-B0; K+                  TcO(OH)3-                            1.65E-1  0  0  0  0  0
+-B1; K+                  TcO(OH)3-                             3.0E-1  0  0  0  0  0
+-B2; K+                  TcO(OH)3-             0  0  0  0  0  0
+-C0; K+                  TcO(OH)3-             0  0  0  0  0  0
+-ALPHAS; K+                  TcO(OH)3-                             2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: KIE/FEL2025
+    # Editor: Kiefer
+
+-B0; Na+                 TcO(OH)3-                           1.085E-1  0  0  0  0  0
+-B1; Na+                 TcO(OH)3-                             3.0E-1  0  0  0  0  0
+-B2; Na+                 TcO(OH)3-             0  0  0  0  0  0
+-C0; Na+                 TcO(OH)3-             0  0  0  0  0  0
+-ALPHAS; Na+                 TcO(OH)3-                             2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: KIE/FEL2025
+    # Editor: Kiefer
+
+-B0; Ca+2                TcO4-                               2.964E-1  0  0  0  0  0
+-B1; Ca+2                TcO4-                               1.661E+0  0  0  0  0  0
+-B2; Ca+2                TcO4-                 0  0  0  0  0  0
+-C0; Ca+2                TcO4-                 0  0  0  0  0  0
+-ALPHAS; Ca+2                TcO4-                                 2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/KON1998
+    # Editor: Kiefer
+
+-B0; K+                  TcO4-                               -5.78E-2  0  0  0  0  0
+-B1; K+                  TcO4-                                 6.0E-3  0  0  0  0  0
+-B2; K+                  TcO4-                 0  0  0  0  0  0
+-C0; K+                  TcO4-                 0  0  0  0  0  0
+-ALPHAS; K+                  TcO4-                                 2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/KON1998
+    # Editor: Kiefer
+
+-B0; Mg+2                TcO4-                               3.138E-1  0  0  0  0  0
+-B1; Mg+2                TcO4-                                1.84E+0  0  0  0  0  0
+-B2; Mg+2                TcO4-                 0  0  0  0  0  0
+-C0; Mg+2                TcO4-                                1.14E-2  0  0  0  0  0
+-ALPHAS; Mg+2                TcO4-                                 2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/KON1998
+    # Editor: Kiefer
+
+-B0; Na+                 TcO4-                               1.111E-2  0  0  0  0  0
+-B1; Na+                 TcO4-                               1.595E-1  0  0  0  0  0
+-B2; Na+                 TcO4-                 0  0  0  0  0  0
+-C0; Na+                 TcO4-                                2.36E-3  0  0  0  0  0
+-ALPHAS; Na+                 TcO4-                                 2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/KON1998
+    # Additional reference: KON/NEC1997
+    # Editor: Kiefer
+
+-B0; Th+4                Cl-                                 1.092E+0  0  0  0  0  0
+-B1; Th+4                Cl-                                  1.37E+1  0  0  0  0  0
+-B2; Th+4                Cl-                                  -1.6E+2  0  0  0  0  0
+-C0; Th+4                Cl-                                 -1.12E-1  0  0  0  0  0
+-ALPHAS; Th+4                Cl-                                   2.0E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: RAI/MOO2000
+    # Additional reference: ROY/VOG1992
+    # Editor: Marquardt
+
+-B0; U(OH)2+2            Cl-                                   3.7E-1  0  0  0  0  0
+-B1; U(OH)2+2            Cl-                                  1.93E+0  0  0  0  0  0
+-B2; U(OH)2+2            Cl-                   0  0  0  0  0  0
+-C0; U(OH)2+2            Cl-                                  -2.9E-2  0  0  0  0  0
+-ALPHAS; U(OH)2+2            Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAN/CEV2023
+    # Editor: Richter
+
+-B0; U(OH)3+             Cl-                                   8.0E-2  0  0  0  0  0
+-B1; U(OH)3+             Cl-                                   3.9E-1  0  0  0  0  0
+-B2; U(OH)3+             Cl-                   0  0  0  0  0  0
+-C0; U(OH)3+             Cl-                   0  0  0  0  0  0
+-ALPHAS; U(OH)3+             Cl-                                   2.0E+0  0
+    # Evaluation ip class: 3, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Description: based on conversion of SIT coefficients, Cphi and ternre parameters unknown (set to be zero); may lead to wrong activity coefficients with increasing ionic strength: parameter set is suitable only for chloride concentration <0.5 M
+    # Editor: Richter
+
+-B0; U(OH)+3             Cl-                                   6.0E-1  0  0  0  0  0
+-B1; U(OH)+3             Cl-                                   5.9E+0  0  0  0  0  0
+-B2; U(OH)+3             Cl-                   0  0  0  0  0  0
+-C0; U(OH)+3             Cl-                   0  0  0  0  0  0
+-ALPHAS; U(OH)+3             Cl-                                   2.0E+0  0
+    # Evaluation ip class: 3, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Description: based on conversion of SIT coefficients, Cphi and ternre parameters unknown (set to be zero); may lead to wrong activity coefficients with increasing ionic strength: parameter set is suitable only for chloride concentration <0.5 M
+    # Editor: Richter
+
+-B0; U(SO4)+2            Cl-                                  1.64E+0  0  0  0  0  0
+-B1; U(SO4)+2            Cl-                   0  0  0  0  0  0
+-B2; U(SO4)+2            Cl-                   0  0  0  0  0  0
+-C0; U(SO4)+2            Cl-                                -2.635E-1  0  0  0  0  0
+-ALPHAS; U(SO4)+2            Cl-                                   2.0E+0  0
+    # Evaluation ip class: 2, data quality: 4
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: RAI/RAO1999
+    # Description: assumed to be identical with values for the corresponding Np(IV) species
+    # Editor: Richter
+
+-B0; U+4                 Cl-                                  1.27E+0  0  0  0  0  0
+-B1; U+4                 Cl-                                  1.35E+1  0  0  0  0  0
+-B2; U+4                 Cl-                   0  0  0  0  0  0
+-C0; U+4                 Cl-                   0  0  0  0  0  0
+-ALPHAS; U+4                 Cl-                                   2.0E+0  0
+    # Evaluation ip class: 3, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Description: values correct in tab.6.2, misprint in tab.7.3; based on conversion of SIT coeff., Cphi and ternary  parameters set to be zero; may lead to extremely wrong act. coeff. with increasing IS: parameter set suitable only for [Cl] <0.5 M
+    # Editor: Richter
+
+-B0; UO2(OH)+            Cl-                                   1.5E-1  0  0  0  0  0
+-B1; UO2(OH)+            Cl-                                   3.0E-1  0  0  0  0  0
+-B2; UO2(OH)+            Cl-                   0  0  0  0  0  0
+-C0; UO2(OH)+            Cl-                   0  0  0  0  0  0
+-ALPHAS; UO2(OH)+            Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Editor: Richter
+
+-B0; UO2+2               Cl-                                 4.274E-1  0  0  0  0  0
+-B1; UO2+2               Cl-                                 1.644E+0  0  0  0  0  0
+-B2; UO2+2               Cl-                   0  0  0  0  0  0
+-C0; UO2+2               Cl-                                 -3.68E-2  0  0  0  0  0
+-ALPHAS; UO2+2               Cl-                                   2.0E+0  0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: PIT1991
+    # Additional reference: PIT/MAY1973
+    # Description: maximum: m=2; standard deviation of the fit sigma=0.001; error in [PIT1991] table 7 (2:1 electrolytes): correct 2^(5/2) /3 * Cphi (not 2/3*2^(5/2) * Cphi); values rounded, original values 0.42735/1.644/-0.03686
+    # Editor: Richter
+
+-B0; UO2+2               SO4-2                                3.22E-1  0  0  0  0  0
+-B1; UO2+2               SO4-2                               1.827E+0  0  0  0  0  0
+-B2; UO2+2               SO4-2                 0  0  0  0  0  0
+-C0; UO2+2               SO4-2                               -1.76E-2  0  0  0  0  0
+-ALPHAS; UO2+2               SO4-2                                 1.4E+0                  1.2E+1
+    # Evaluation ip class: 1, data quality: 4
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: PIT1991
+    # Additional reference: PIT/MAY1974
+    # Description: range 0-1-5.0 m; standard deviation of the fit sigma=0.003
+    # Editor: Richter
+
+-B0; Zn+2                Cl-                                 6.522E-2  0  0  0  0  0
+-B1; Zn+2                Cl-                                5.5187E+0  0  0  0  0  0
+-B2; Zn+2                Cl-                               -4.3578E+0  0  0  0  0  0
+-C0; Zn+2                Cl-                              3.733524E-3  0  0  0  0  0
+-ALPHAS; Zn+2                Cl-                                   2.0E+0                  2.5E+0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2022
+    # Editor: Moog
+
+-B0; Zn+2                SO4-2                              1.8207E-1  0  0  0  0  0
+-B1; Zn+2                SO4-2                               2.943E+0  0  0  0  0  0
+-B2; Zn+2                SO4-2                             -1.9789E+2  0  0  0  0  0
+-C0; Zn+2                SO4-2                               3.344E-2  0  0  0  0  0
+-ALPHAS; Zn+2                SO4-2                                 1.4E+0                  2.0E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2022
+    # Editor: Moog
+
+# #### all theta coefficients ##################################################
+-THETA
+(UO2)3(OH)4+2       Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Editor: Richter
+
+Al(OH)4-            CO3-2                                  1.0E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Al(OH)4-            Cl-                                   -4.5E-2                  -4.9E+1   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Al(OH)4-            OH-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Al+3                Ca+2                   0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 343.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Al+3                H+                                    1.85E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 373.15 K.
+    # Reference: MIR2023
+    # Additional reference: PIT/MAY1973
+    # Editor: Miron
+
+Al+3                K+                                    -2.0E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 363.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Al+3                Mg+2                   0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 353.13 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Al+3                Na+                                   3.35E-1                   3.5E+1   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 373.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Am(CO3)2-           Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Additional reference: FAN/KON1999
+    # Description: theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters (analogy to Cm(CO3)2<->)
+    # Editor: Marquardt
+
+Am(CO3)3-3          Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Additional reference: FAN/KON1999
+    # Description: theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters (analogy to Cm(CO3)3<3->)
+    # Editor: Marquardt
+
+Am(CO3)+            Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Additional reference: FAN/KON1999
+    # Description: theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters (analogy to Cm(CO3)<+>)
+    # Editor: Marquardt
+
+Am(NO3)2+           Mg+2                             -2.854448E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Am(NO3)2+           Na+                              -2.488491E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Am(NO3)+2           Mg+2                              9.676067E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Am(NO3)+2           Na+                                -5.4943E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Am(OH)2+            Ca+2                                   2.9E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: Pitzer parameter were deduced from Cm-Data and refined by Nd(OH)3(s) and Am(OH)3(s) data.
+    # Editor: Marquardt
+
+Am(OH)2+            Mg+2                                   2.9E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: value from: Nd(OH)2<+> and Am(OH)2<+> data (and from interaction with Ca<2+>)
+    # Editor: Marquardt
+
+Am(OH)2+            Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: Pitzer parameter were deduced from Cm-Data.
+    # Editor: Marquardt
+
+Am(OH)4-            Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+Am(OH)4-            OH-                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+Am(OH)+2            Ca+2                   0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+Am(OH)+2            Mg+2                   0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from interaction with Ca<2+>
+    # Editor: Marquardt
+
+Am(OH)+2            Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+Am(SO4)2-           Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Description: analogue value from: Cm(SO4)2<->; theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters
+    # Editor: Marquardt
+
+Am(SO4)2-           SO4-2                  0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Description: analogue value from: Cm(SO4)2<->; theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters
+    # Editor: Marquardt
+
+Am(SO4)+            Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Description: analogue value from: Cm(SO4)<+>; theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters
+    # Editor: Marquardt
+
+Am+3                Ca+2                                   2.0E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Nd<3+>
+    # Editor: Marquardt
+
+Am+3                K+                                     1.0E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: ALT/BRE2004
+    # Description: analogue value from: Nd<3+> and Na<+>
+    # Editor: Marquardt
+
+Am+3                Mg+2                                   2.0E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Nd<3+> and Ca<2+>
+    # Editor: Marquardt
+
+Am+3                Na+                                    1.0E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Nd<3+>
+    # Editor: Marquardt
+
+AmCl2+              Ca+2                                 -1.96E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: CmCl2<+>. Cm(III)-data from KON/FAN1997
+    # Editor: Marquardt
+
+AmCl2+              Mg+2                                 -1.96E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from CmCl2<+> interaction with Ca<2+> [KON/FAN1997]
+    # Editor: Marquardt
+
+AmCl2+              Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: CmCl2<+>. Cm(III)-data from KON/FAN1997
+    # Editor: Marquardt
+
+AmCl+2              Ca+2                                  -1.4E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: CmCl<2+>. Cm(III)-data from KON/FAN1997
+    # Editor: Marquardt
+
+AmCl+2              Mg+2                                  -1.4E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from CmCl<2+> interaction with Ca<2+> [KON/FAN1997]
+    # Editor: Marquardt
+
+AmCl+2              Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: CmCl<2+>. Cm(III)-data from KON/FAN1997
+    # Editor: Marquardt
+
+CO3-2               HCO3-                            4.9628191E-3   0   0               8.93501E-5   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Description: 
+    # Editor: Freyer
+
+CO3-2               SiO2(OH)2-2            0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Ca2(Am(OH)4)+3      Ca+2                   0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Ca2[Cm(OH)4]<3+>
+    # Editor: Marquardt
+
+Ca2(Cm(OH)4)+3      Ca+2                   0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+Ca2(Nd(OH)4)+3      Ca+2                   0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Ca2[Cm(OH)4]<3+>
+    # Editor: Marquardt
+
+Ca3(Am(OH)6)+3      Ca+2                   0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Ca3[Cm(OH)6]<3+>
+    # Editor: Marquardt
+
+Ca3(Cm(OH)6)+3      Ca+2                   0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+Ca3(Nd(OH)6)+3      Ca+2                   0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Ca3[Cm(OH)6]<3+>
+    # Editor: Marquardt
+
+Ca+2                H+                         9.6861568224187E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Ca+2                Mg(OH)+                0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Ca(Am(OH)3)+2       Ca+2                   0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Ca[Cm(OH)3]<2+>
+    # Editor: Marquardt
+
+Ca(Cm(OH)3)+2       Ca+2                   0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+Ca(Nd(OH)3)+2       Ca+2                   0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Ca[Cm(OH)3]<2+>
+    # Editor: Marquardt
+
+Cd+2                Ca+2                               -2.6274E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2024
+    # Editor: Moog
+
+Cd+2                K+                                  -6.308E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2024
+    # Editor: Moog
+
+Cd+2                Mg+2                               -4.1211E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2024
+    # Editor: Moog
+
+Cd+2                Na+                                 -6.474E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2024
+    # Editor: Moog
+
+Cl-                 CO3-2                                 -2.0E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+Cl-                 H2PO4-                              1.0037E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+Cl-                 HCO3-                                  3.0E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+Cl-                 HPO4-2                               7.083E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+Cl-                 HSO4-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Cl-                 NO3-                                 1.629E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MUN2024
+    # Editor: Moog
+
+Cl-                 PO4-3                               2.4341E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+Cl-                 SO4-2                       1.999975951872E-2      6.14522608936196E+2   0      6.62042337362439E-3   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Cl-                 SiO2(OH)2-2                           -2.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 573.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Cm(CO3)2-           Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FAN/KON1999
+    # Description: theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters
+    # Editor: Marquardt
+
+Cm(CO3)3-3          Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FAN/KON1999
+    # Description: theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters
+    # Editor: Marquardt
+
+Cm(CO3)4-5          Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FAN/KON1999
+    # Description: theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters
+    # Editor: Marquardt
+
+Cm(CO3)+            Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FAN/KON1999
+    # Description: theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters
+    # Editor: Marquardt
+
+Cm(NO3)2+           Mg+2                             -2.854448E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Cm(NO3)2+           Na+                              -2.488491E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Cm(NO3)+2           Mg+2                              9.676067E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Cm(NO3)+2           Na+                                -5.4943E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Cm(OH)2+            Ca+2                                   2.9E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Nd(OH)2<+> and Am(OH)2<+>
+    # Editor: Marquardt
+
+Cm(OH)2+            Mg+2                                   2.9E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from Nd(OH)2<+> and Am(OH)2<+> interaction with Ca<2+>
+    # Editor: Marquardt
+
+Cm(OH)2+            Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Nd(OH)2<+> and Am(OH)2<+>
+    # Editor: Marquardt
+
+Cm(OH)+2            Ca+2                   0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: The Pitzer parameters for these species have therefore been adjusted to the present solubility data for Nd(OH)3(s) and literature data for the solubility of aged  Am(OH)3(s)
+    # Editor: Marquardt
+
+Cm(OH)+2            Mg+2                   0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from interaction with Ca<2+>
+    # Editor: Marquardt
+
+Cm(OH)+2            Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: NEC/FAN1998
+    # Editor: Marquardt
+
+Cm(SO4)2-           Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Description: theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters
+    # Editor: Marquardt
+
+Cm(SO4)2-           SO4-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Description: theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters
+    # Editor: Marquardt
+
+Cm(SO4)+            Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Description: theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters
+    # Editor: Marquardt
+
+Cm+3                Ca+2                                   2.0E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Nd<3+>
+    # Editor: Marquardt
+
+Cm+3                K+                                     1.0E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: ALT/BRE2004
+    # Description: analogue value from: Nd<3+> and Na<+>
+    # Editor: Marquardt
+
+Cm+3                Mg+2                                   2.0E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Nd<3+> and Ca<2+>
+    # Editor: Marquardt
+
+Cm+3                Na+                                    1.0E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Nd<3+>
+    # Editor: Marquardt
+
+CmCl2+              Ca+2                                 -1.96E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: Cm(III) data from KON/FAN1997
+    # Editor: Marquardt
+
+CmCl2+              Mg+2                                 -1.96E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from interaction with Ca<2+> (Cm(III) data from KON/FAN1997)
+    # Editor: Marquardt
+
+CmCl2+              Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+CmCl+2              Ca+2                                  -1.4E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: Cm(III) data from KON/FAN1997
+    # Editor: Marquardt
+
+CmCl+2              Mg+2                                  -1.4E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from interaction with Ca<2+> (Cm(III) data from KON/FAN1997)
+    # Editor: Marquardt
+
+CmCl+2              Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+Cs+                 Ca+2                                -9.812E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2013
+    # Editor: Moog
+
+Cs+                 K+                                   -5.55E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2013
+    # Editor: Moog
+
+Cs+                 Mg+2                               -1.3117E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2013
+    # Editor: Moog
+
+Cs+                 Na+                                 -1.676E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2013
+    # Editor: Moog
+
+H2PO4-              HPO4-2                             -3.2361E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+H+                  Mg(OH)+                0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+HCO3-               SiO2(OH)2-2                           -4.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+K+                  Ca+2                       1.1559860965783E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+K+                  H+                         1.5377431744399E-2     -5.58753592639365E+1   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+K+                  Mg+2                      9.6357988255136E-10      -1.0485973881773E+3   0      -7.9210297311925E-3   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Mg+2                Ca+2                      -1.8035230826513E-2     -4.78562805821156E+3      -4.2263061386734E+1      1.23291718082867E-1     -5.95234679174935E-5   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Mg+2                H+                         1.0115592702734E-1   0   0     -3.13096805580612E-3      5.82850132900355E-6   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Mg+2                Mg(OH)+                0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Mg+2                Mg3(OH)4+2             0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+NO3-                SO4-2                                9.972E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MUN2024
+    # Editor: Moog
+
+Na+                 Ca+2                       5.8133189525464E-2      2.26721171279933E+3      1.40147720079379E+1     -2.12735153045884E-2   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Na+                 H+                         3.4537720691614E-2     -4.05425758855012E+0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Na+                 K+                        -1.1999855679855E-2   0   0      1.47816722111973E-7   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Na+                 Mg(OH)+                0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Na+                 Mg3(OH)4+2             0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Na+                 Mg+2                       6.9999158088045E-2   0   0      4.47233320945336E-4   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Nd(NO3)2+           Mg+2                             -2.854448E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Nd(NO3)2+           Na+                              -2.488491E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Nd(NO3)+2           Mg+2                              9.676067E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Nd(NO3)+2           Na+                                -5.4943E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Nd(OH)2+            Ca+2                                   2.9E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: value from TRLFS Cm data
+    # Editor: Marquardt
+
+Nd(OH)2+            Mg+2                                   2.9E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: value from TRLFS Cm data
+    # Editor: Marquardt
+
+Nd(OH)2+            Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: value from TRLFS Cm data
+    # Editor: Marquardt
+
+Nd(OH)4-            Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Am(OH)4<-> interaction
+    # Editor: Marquardt
+
+Nd(OH)4-            OH-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Am(OH)4<-> interaction
+    # Editor: Marquardt
+
+Nd(OH)+2            Ca+2                   0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: value from TRLFS Cm(OH)2<+> data
+    # Editor: Marquardt
+
+Nd(OH)+2            Mg+2                   0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Cm(OH)<2+> and Am(OH)<2+> interaction with Ca<2+>
+    # Editor: Marquardt
+
+Nd(OH)+2            Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: NEC/FAN1998
+    # Description: analogue value from: Cm(OH)<2+> and Am(OH)<2+>
+    # Editor: Marquardt
+
+Nd+3                Ca+2                                   2.0E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Editor: Marquardt
+
+Nd+3                K+                                     1.0E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: ALT/BRE2004
+    # Description: analogue value from: Nd<3+> and Na<+>
+    # Editor: Marquardt
+
+Nd+3                Mg+2                                   2.0E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Nd<3+> and Ca<2+>
+    # Editor: Marquardt
+
+Nd+3                Na+                                    1.0E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Editor: Marquardt
+
+NdCl2+              Ca+2                                 -1.96E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: CmCl2<+>. Cm(III)-data from KON/FAN1997
+    # Editor: Marquardt
+
+NdCl2+              Mg+2                                 -1.96E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: CmCl2<+> and Ca<2+>. Cm(III) data from KON/FAN1997
+    # Editor: Marquardt
+
+NdCl2+              Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: CmCl2<+>. Cm(III)-data from KON/FAN1997
+    # Editor: Marquardt
+
+NdCl+2              Ca+2                                  -1.4E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: CmCl<2+>. Cm(III)-data from KON/FAN1997
+    # Editor: Marquardt
+
+NdCl+2              Mg+2                                  -1.4E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: CmCl<2+> and Ca<2+>. Cm(III) data from KON/FAN1997
+    # Editor: Marquardt
+
+NdCl+2              Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: CmCl<2+>. Cm(III)-data from KON/FAN1997
+    # Editor: Marquardt
+
+NpO2(CO3)2-3        Cl-                                   -2.6E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Editor: Marquardt
+
+NpO2(CO3)3-5        CO3-2                                 -1.9E+0   0   0   0   0   0
+    # Evaluation ip class: 5, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Additional reference: NOV/MAH1997
+    # Description: A value of -0.83 should be used for carbonate concentrations more than 1 molal. However, the corresponding value of the solubility product, obtained by fitting, is lower than the value in the THEREDA database.
+    # Editor: Marquardt
+
+NpO2(CO3)3-5        Cl-                                   -2.6E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Editor: Marquardt
+
+NpO2(CO3)-          Cl-                                   -2.1E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Editor: Marquardt
+
+NpO2(OH)2-          Cl-                                   -2.4E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FAN/NEC1995
+    # Additional reference: NEC1997
+    # Editor: Marquardt
+
+NpO2+               Ca+2                                   9.0E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FEL/ALT2016
+    # Editor: Gaona
+
+NpO2+               K+                     0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Editor: Marquardt
+
+NpO2+               Mg+2                                   5.0E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Editor: Marquardt
+
+NpO2+               Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FAN/NEC1995
+    # Editor: Marquardt
+
+OH-                 CO3-2                             4.479975E-2   0   0                2.0446E-4   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+OH-                 Cl-                        -5.507306101229E-2     -4.93613455048409E+1   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+OH-                 HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+OH-                 SO4-2                     -1.1626071686011E-2   0      1.45311584581153E-1     -2.27229389620542E-3      1.95384233567863E-6   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+OH-                 SiO2(OH)2-2            0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+PO4-3               HPO4-2                              2.5528E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+SO4-2               Al(OH)4-                             -1.16E-2   0                1.4531E-1               -2.2723E-3                1.9538E-6   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+SO4-2               CO3-2                                  2.0E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+SO4-2               H2PO4-                              1.3769E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+SO4-2               HCO3-                                  1.0E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+SO4-2               HPO4-2                               9.124E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+SO4-2               HSO4-                     -1.1850909386158E-1       1.2105980972999E+5      4.78648418786457E+2     -8.33977011365686E-1       2.7042821215948E-4     -5.70402341692224E+6
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+SO4-2               PO4-3                              1.09665E+0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+SO4-2               PbCl3-                               4.973E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Editor: Moog
+
+SO4-2               PbCl4-2                             -2.334E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Editor: Moog
+
+SO4-2               SiO(OH)3-                              1.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+SeO3-2              Cl-                                  -7.75E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG/MOO2012
+    # Editor: Bok
+
+SeO3-2              SO4-2                                5.692E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG/MOO2012
+    # Editor: Bok
+
+SeO4-2              CO3-2                                1.997E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: BOK2021
+    # Editor: Bok
+
+SeO4-2              Cl-                                   3.17E-3   0   0               5.07444E-5   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: BIS/HAG2016
+    # Editor: Bok
+
+SeO4-2              OH-                                 -6.208E-2   0   0       4.1714285714286E-4   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 291.15 K - 298.15 K.
+    # Reference: BOK2021
+    # Editor: Bok
+
+SeO4-2              SO4-2                               -5.898E-2   0   0              -1.96229E-3   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: BIS/HAG2016
+    # Description: All ternary interaction coefficients for the systems Na,K,Mg - Cl,SO4,SeO4 - H2O were derived from constructed isoactivity lines.
+    # Editor: Bok
+
+SiO(OH)3-           CO3-2                                 -4.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+SiO(OH)3-           Cl-                                    3.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 573.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+SiO(OH)3-           HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+SiO(OH)3-           OH-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Description: Measured osmotic coefficient in Na2SiO3 and NOH solutions 298.15 K
+    # Editor: Miron
+
+SiO(OH)3-           SiO2(OH)2-2                            2.0E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+SiO2(OH)2-2         Al(OH)4-               0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+SiO2(OH)2-2         SO4-2                                  2.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Sr+2                Ca+2                                4.5946E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH2016
+    # Editor: Moog
+
+Sr+2                K+                                  4.1523E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH2016
+    # Editor: Moog
+
+Sr+2                Mg+2                                1.4857E-3   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH2016
+    # Editor: Moog
+
+Sr+2                Na+                                1.01684E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH2016
+    # Editor: Moog
+
+TcO4-               Cl-                                    6.7E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/KON1998
+    # Additional reference: KON/NEC1997
+    # Editor: Kiefer
+
+Th(CO3)5-6          Cl-                                    1.8E+0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MAR/GAO2014
+    # Additional reference: RAI/MOO2000
+    # Editor: Marquardt
+
+Th+4                H+                                     6.0E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MAR/GAO2014
+    # Additional reference: RAI/MOO2000
+    # Editor: Marquardt
+
+Th+4                Na+                                    4.2E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MAR/GAO2014
+    # Additional reference: RAI/MOO2000
+    # Editor: Marquardt
+
+UO2(CO3)2-2         Cl-                                   -2.5E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Description: Estimated value assuming that a/Cl-= -0.250.1 for a=Np(V)-cabonato complex NpO2(CO3)n1-2n with n=1-3 ([RUN/NEU1996]), valid only for low ionic strength (<0-5-1m)
+    # Editor: Richter
+
+UO2(CO3)3-4         Cl-                                   -2.5E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Description: Estimated value assuming that a/Cl-= -0.250.1 for a=Np(V)-cabonato complex NpO2(CO3)n1-2n with n=1-3 ([RUN/NEU1996]), valid only for low ionic strength (<0-5-1m)
+    # Editor: Richter
+
+UO2+2               Mg+2                                   8.0E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Editor: Richter
+
+UO2+2               Na+                                    3.0E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Editor: Richter
+
+Zn+2                Ca+2                               -1.6835E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2022
+    # Editor: Moog
+
+Zn+2                K+                                 -3.1819E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2022
+    # Editor: Moog
+
+Zn+2                Mg+2                               -6.9247E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2022
+    # Editor: Moog
+
+Zn+2                Na+                                -1.2816E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2022
+    # Editor: Moog
+
+# #### all lambda coefficients #################################################
+-LAMBDA
+CO2                 Al+3                                   2.4E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+CO2                 CO3-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+CO2                 Ca+2                                  1.83E-1   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 3
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+CO2                 Cl-                                   -5.0E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Description: 
+    # Editor: Freyer
+
+CO2                 H+                     0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 0
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Description: 
+    # Editor: Freyer
+
+CO2                 HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+CO2                 HSO4-                                 -3.0E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+CO2                 K+                                     5.1E-2   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: REA1990
+    # Editor: Freyer
+
+CO2                 Mg(OH)+                0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+CO2                 Mg+2                                  1.83E-1   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 3
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+CO2                 Na+                                    1.0E-1   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 3
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+CO2                 OH-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+CO2                 SO4-2                                  9.7E-2   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: REA1990
+    # Editor: Miron
+
+UO2(CO3)            Mg+2                   0   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Description: estimated value according to SIT with epsilon(ik)=0 for neutral species
+    # Editor: Richter
+
+UO2(CO3)            Na+                                    5.0E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Additional reference: PAS/CZE1997
+    # Description: valid until 3.5 M NaClO4
+    # Editor: Richter
+
+NpO2(OH)            Cl-                                   -1.9E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FAN/NEC1995
+    # Additional reference: NEC1997
+    # Editor: Marquardt
+
+NpO2(OH)            K+                     0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Description: estimated based on analogies of charge and ionic radius
+    # Editor: Marquardt
+
+NpO2(OH)            Mg+2                   0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Description: estimated based on analogies of charge and ionic radius
+    # Editor: Marquardt
+
+NpO2(OH)            Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FAN/NEC1995
+    # Additional reference: NEC1997
+    # Editor: Marquardt
+
+NpO2Cl              Ca+2                                   1.1E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FEL/ALT2016
+    # Editor: Gaona
+
+NpO2Cl              Cl-                                    1.1E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FEL/ALT2016
+    # Editor: Gaona
+
+UO2(CO3)            SO4-2                  0   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 4
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Description: estimated value according to SIT with epsilon(ik)=0 for neutral species
+    # Editor: Richter
+
+U(SO4)2             Cl-                                    2.9E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 4
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: RAI/RAO1999
+    # Editor: Richter
+
+UO2(CO3)            Cl-                                   -2.5E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Description: estimated value assuming that theta(a,Cl<->)=-0.25+-0.1 for a=Np(V)-carbonato complex NpO2(CO3)n<1-2n> with n=1-3 ([RUN/NEU1996])
+    # Editor: Richter
+
+Al(OH)3             Ca+2                                   3.5E-1                  1.44E+2   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Al(OH)3             Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 0
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Al(OH)3             HCO3-                                 -5.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 373.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Al(OH)3             K+                                     4.0E-2                   4.0E+1   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Al(OH)3             Mg+2                                   3.5E-1                  1.44E+2   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Al(OH)3             Na+                                    1.0E-1                   4.0E+1   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Al(OH)3             SO4-2                                 -1.5E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Am(OH)3             Ca+2                   0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+Am(OH)3             Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+Am(OH)3             K+                     0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+Am(OH)3             Mg+2                   0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+Am(OH)3             Na+                                   -2.0E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: Cm(OH)3<0>
+    # Editor: Marquardt
+
+Am(OH)3             OH-                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+PbCl2               Ca+2                                  1.63E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Editor: Moog
+
+UO2(OH)2            Ca+2                   0   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Description: estimated value according to SIT with epsilon(ik)=0 for neutral species
+    # Editor: Richter
+
+CaSiO2(OH)2         CO3-2                                 -1.5E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+CaSiO2(OH)2         Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 0
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+CaSiO2(OH)2         HCO3-                                 -5.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 432.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+CaSiO2(OH)2         K+                                     4.0E-2                   4.0E+1   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Description: analogue to (Si(OH)4<0>,K<+>)
+    # Editor: Miron
+
+CaSiO2(OH)2         Na+                                    1.0E-1                   4.0E+1   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Description: analogue to (Si(OH)4<0>,Na<+>)
+    # Editor: Miron
+
+CaSiO2(OH)2         SO4-2                                 -1.5E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Cd(OH)2             Na+                                   -1.5E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2024
+    # Editor: Moog
+
+Cm(OH)3             Ca+2                   0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: anologue value from:Am(OH)3<0>
+    # Editor: Marquardt
+
+Cm(OH)3             Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: anologue value from:Am(OH)3<0>
+    # Editor: Marquardt
+
+Cm(OH)3             K+                     0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: anologue value from:Am(OH)3<0>
+    # Editor: Marquardt
+
+Cm(OH)3             Mg+2                   0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: anologue value from:Am(OH)3<0>
+    # Editor: Marquardt
+
+Cm(OH)3             Na+                                   -2.0E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Editor: Marquardt
+
+Cm(OH)3             OH-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: anologue value from:Am(OH)3<0>
+    # Editor: Marquardt
+
+PbCl2               K+                                  -1.974E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Editor: Moog
+
+U(OH)4              K+                     0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Description: estimated resp. to Pitzer parameters of analogue species, set to be zero, Cphi and ternre parameters unknown (set to be zero); wrong activity coefficients with increasing ionic strength: parameter set is suitable only for chloride concentration <0.5 M
+    # Editor: Richter
+
+UO2(OH)2            K+                     0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Additional reference: NEC/FAN2001
+    # Editor: Richter
+
+PbCl2               Mg+2                                 2.143E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Editor: Moog
+
+U(OH)4              Mg+2                   0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Description: estimated resp. to Pitzer parameters of analogue species, set to be zero, Cphi and ternre parameters unknown (set to be zero); wrong activity coefficients with increasing ionic strength: parameter set is suitable only for chloride concentration <0.5 M
+    # Editor: Richter
+
+UO2(OH)2            Mg+2                   0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Additional reference: NEC/FAN2001
+    # Editor: Richter
+
+MgSiO2(OH)2         CO3-2                                 -1.5E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Description: analogue with (Si(OH)4<0>,CO3<2->)
+    # Editor: Miron
+
+MgSiO2(OH)2         Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 0
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+MgSiO2(OH)2         HCO3-                                 -5.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Description: (Si(OH)4<0>,HCO3<->)
+    # Editor: Miron
+
+MgSiO2(OH)2         K+                                     4.0E-2                   4.0E+1   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Description: analogue to (Si(OH)4<0>,K<+>)
+    # Editor: Miron
+
+MgSiO2(OH)2         Na+                                    1.0E-1                   4.0E+1   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Description: analogue to (Si(OH)4<0>,Na<+>)
+    # Editor: Miron
+
+MgSiO2(OH)2         SO4-2                                 -1.5E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Description: analogue with (Si(OH)4<0>,SO4<2->)
+    # Editor: Miron
+
+PbCl2               Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 0
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Editor: Moog
+
+U(OH)4              Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Description: estimated resp. to Pitzer parameters of analogue species, set to be zero, Cphi and ternre parameters unknown (set to be zero); wrong activity coefficients with increasing ionic strength: parameter set is suitable only for chloride concentration <0.5 M
+    # Editor: Richter
+
+UO2(OH)2            Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Additional reference: NEC/FAN2001
+    # Editor: Richter
+
+Nd(OH)3             Ca+2                   0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: anologue value from:Am(OH)3<0>
+    # Editor: Marquardt
+
+Nd(OH)3             Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: anologue value from:Am(OH)3<0>
+    # Editor: Marquardt
+
+Nd(OH)3             K+                     0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: anologue value from:Am(OH)3<0>
+    # Editor: Marquardt
+
+Nd(OH)3             Mg+2                   0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: anologue value from:Am(OH)3<0>
+    # Editor: Marquardt
+
+Nd(OH)3             Na+                                   -2.0E-1   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: anologue value from: Cm(OH)3<0>
+    # Editor: Marquardt
+
+Nd(OH)3             OH-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: anologue value from:Am(OH)3<0>
+    # Editor: Marquardt
+
+Np(OH)4             Ca+2                   0   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+Np(OH)4             Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+Np(OH)4             K+                     0   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+Np(OH)4             Mg+2                   0   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+Np(OH)4             Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+O2                  CO3-2                                3.234E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  Ca+2                                 2.519E-1                 2.821E+3                 9.449E+0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 278.15 K - 318.15 K.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 0
+    # Temperature range min - max: 278.15 K - 318.15 K.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  H2PO4-                               3.718E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  H3PO4                                4.841E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  H+                                   2.598E-2                 4.941E+3                  1.64E+1   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 288.15 K - 310.2 K.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  HPO4-2                               2.512E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  HSO4-                                3.842E-2                -4.538E+1   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 288.15 K - 310.2 K.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  K+                                    1.35E-1                -1.004E+3                -3.513E+0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 278.15 K - 318.15 K.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  Mg+2                                 2.293E-1                 2.981E+3                   9.9E+0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 278.15 K - 318.15 K.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  Na+                                  1.315E-1                 2.897E+3                 9.614E+0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 318.15 K.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  OH-                                  6.785E-2                  1.23E+3                 3.934E+0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 288.15 K - 373.15 K.
+    # Reference: BOK/MOO2023
+    # Description: Typo in publication: X2 term must be 3.934  0.882, not 3.6934  0.882
+    # Editor: Bok
+
+O2                  PO4-3                                2.946E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  SO4-2                                1.334E-1                -6.654E+3                -2.201E+1   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 278.15 K - 318.15 K.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+Pu(OH)4             Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+Pu(OH)4             Mg+2                   0   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+Pu(OH)4             Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+PbCl2               SO4-2                                -5.05E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Editor: Moog
+
+Si(OH)4             Ca+2                                   3.5E-1                  1.44E+2   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 573.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Si(OH)4             Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 273.15 K - 573.15 K.
+    # Reference: MIR2023
+    # Description: 
+    # Editor: Miron
+
+Si(OH)4             H+                                    1.46E-1                   4.0E+1   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: MIR2023
+    # Description: Fitted against data up to 373.15
+    # Editor: Miron
+
+Si(OH)4             HCO3-                                 -5.0E-2                   4.0E+1   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Description: Experimental data available only for 298.15. Can be extrapolated to elevated temperatures assuming that the second temperature function coefficient B (Si(OH)4<0>,Na<+>) + B (Si(OH)4<0>,HCO3<->) = 40, which makes (Si(OH)4<0>,HCO3<->) = 0 
+    # Editor: Miron
+
+Si(OH)4             K+                                     4.0E-2                   4.0E+1   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 573.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Si(OH)4             Mg+2                                   3.5E-1                  1.44E+2   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 273.15 K - 573.15 K.
+    # Reference: MIR2023
+    # Description: in analogy to Mg<2+> interaction
+    # Editor: Miron
+
+Si(OH)4             Na+                                    1.0E-1                   4.0E+1   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 573.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Si(OH)4             SO4-2                                 -1.5E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 573.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Th(OH)4             Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC2000
+    # Editor: Marquardt
+
+U(OH)4              Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Description: estimated resp. to Pitzer parameters of analogue species, set to be zero, Cphi and ternre parameters unknown (set to be zero); wrong activity coefficients with increasing ionic strength: parameter set is suitable only for chloride concentration <0.5 M
+    # Editor: Richter
+
+UO2(OH)2            Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Additional reference: NEC/FAN2001
+    # Editor: Richter
+
+UO2(OH)2            SO4-2                  0   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 4
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Description: estimated value according to SIT with epsilon(ik)=0 for neutral species
+    # Editor: Richter
+
+UO2(SO4)            Ca+2                   0   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 4
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Editor: Richter
+
+UO2(SO4)            Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 4
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Editor: Richter
+
+UO2(SO4)            K+                     0   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 4
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Editor: Richter
+
+UO2(SO4)            Mg+2                   0   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 4
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Editor: Richter
+
+UO2(SO4)            Na+                    0   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 4
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Editor: Richter
+
+UO2(SO4)            SO4-2                  0   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 4
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN2001
+    # Editor: Richter
+
+# #### all psi coefficients ####################################################
+-PSI
+(UO2)3(OH)4+2       Na+                 Cl-                                    2.0E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Editor: Richter
+
+K+                  Al(OH)4-            CO3-2                                 -1.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+K+                  Al(OH)4-            OH-                                   -3.0E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 423.14 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Na+                 Al(OH)4-            CO3-2                                 -1.7E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Na+                 Al(OH)4-            OH-                                   -3.0E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Al+3                Ca+2                Cl-                                   -5.8E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 343.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Al+3                Ca+2                SO4-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 353.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Al+3                H+                  Cl-                                    1.3E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 373.15 K.
+    # Reference: MIR2023
+    # Additional reference: PIT/MAY1974
+    # Editor: Miron
+
+Al+3                H+                  SO4-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Al+3                K+                  Cl-                                   -2.0E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 363.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Al+3                K+                  SO4-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Al+3                Mg+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 353.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Al+3                Mg+2                SO4-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Al+3                Na+                 Cl-                                   -3.9E-2                   1.4E+1   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 373.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Al+3                Na+                 SO4-2                                 -9.0E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Na+                 Am(CO3)2-           Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Additional reference: FAN/KON1999
+    # Description: theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters (analogy to Cm(CO3)2<->)
+    # Editor: Marquardt
+
+Na+                 Am(CO3)3-3          Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FAN/KON1999
+    # Additional reference: NEC/FAN1998
+    # Description: theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters (analogy to Cm(CO3)3<3->)
+    # Editor: Marquardt
+
+Am(CO3)+            Na+                 Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Additional reference: FAN/KON1999
+    # Description: theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters (analogy to Cm(CO3)<+>)
+    # Editor: Marquardt
+
+Am(NO3)2+           Mg+2                NO3-                                 3.341E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Am(NO3)2+           Na+                 NO3-                                  -2.0E-4   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Am(NO3)+2           Mg+2                NO3-                                -1.024E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Am(NO3)+2           Na+                 NO3-                                -1.111E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Am(OH)2+            Ca+2                Cl-                                    7.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: Pitzer parameter were deduced from Cm-Data and refined by Nd(OH)3(s) and Am(OH)3(s) data.
+    # Editor: Marquardt
+
+Am(OH)2+            Ca+2                NO3-                                   7.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+Am(OH)2+            Mg+2                Cl-                                    7.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from Nd(OH)2<+> and Am(OH)2<+> interaction with Ca<2+>
+    # Editor: Marquardt
+
+Am(OH)2+            Mg+2                NO3-                                   7.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+Am(OH)2+            Na+                 Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: value from: Nd(OH)2<+> and Am(OH)2<+> data
+    # Editor: Marquardt
+
+Ca+2                Am(OH)4-            Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+K+                  Am(OH)4-            Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: from interaction with Na<+>
+    # Editor: Marquardt
+
+Mg+2                Am(OH)4-            Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: from interaction with Ca<2+>
+    # Editor: Marquardt
+
+Na+                 Am(OH)4-            Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+K+                  Am(OH)4-            OH-                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+Na+                 Am(OH)4-            OH-                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+Am(OH)+2            Ca+2                Cl-                                    4.0E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+Am(OH)+2            Ca+2                NO3-                                   4.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+Am(OH)+2            Mg+2                Cl-                                    4.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from interaction with Ca<2+>
+    # Editor: Marquardt
+
+Am(OH)+2            Mg+2                NO3-                                   4.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+Am(OH)+2            Na+                 Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+Na+                 Am(SO4)2-           Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Description: analogue value from: Cm(SO4)2<->; theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters
+    # Editor: Marquardt
+
+Na+                 Am(SO4)2-           SO4-2                  0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Description: analogue value from: Cm(SO4)2<->; theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters
+    # Editor: Marquardt
+
+Am(SO4)+            Na+                 Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Description: analogue value from: Cm(SO4)<+>; theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters
+    # Editor: Marquardt
+
+Am(SO4)+            Na+                 SO4-2                  0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Description: analogue value from: Cm(SO4)<+>; theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters
+    # Editor: Marquardt
+
+Am+3                Ca+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: Cm<3+>, applicable to Am, Cm, Pu, Nd
+    # Editor: Marquardt
+
+Am+3                K+                  Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: ALT/BRE2004
+    # Description: analogue value from: Nd<3+> and Na<+>
+    # Editor: Marquardt
+
+Am+3                Mg+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Nd<3+> and Ca<2+>
+    # Editor: Marquardt
+
+Am+3                Mg+2                NO3-                   0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Am+3                Na+                 Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Nd<3+>
+    # Editor: Marquardt
+
+Am+3                Na+                 NO3-                   0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+AmCl2+              Ca+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: CmCl2<+>. Cm(III)-data from KON/FAN1997
+    # Editor: Marquardt
+
+AmCl2+              Mg+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from CmCl<2+> interaction with Ca<2+> (Cm(III) data from KON/FAN1997)
+    # Editor: Marquardt
+
+AmCl2+              Na+                 Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from CmCl<2+> (Cm(III) data from KON/FAN1997)
+    # Editor: Marquardt
+
+AmCl+2              Ca+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: CmCl<2+>. Cm(III)-data from KOE/FAN1997
+    # Editor: Marquardt
+
+AmCl+2              Mg+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from CmCl<2+> interaction with Ca<2+> (Cm(III) data from KON/FAN1997)
+    # Editor: Marquardt
+
+AmCl+2              Na+                 Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from CmCl<2+> (Cm(III) data from KON/FAN1997)
+    # Editor: Marquardt
+
+Ca+2                CO3-2               Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+Mg+2                CO3-2               Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+H+                  CO3-2               HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+K+                  CO3-2               HCO3-                                  1.2E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+Mg(OH)+             CO3-2               HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Na+                 CO3-2               HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+K+                  CO3-2               SiO(OH)3-                              1.2E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Na+                 CO3-2               SiO(OH)3-                              2.0E-3   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+K+                  CO3-2               SiO2(OH)2-2            0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Na+                 CO3-2               SiO2(OH)2-2            0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Ca2(Am(OH)4)+3      Ca+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Ca2[Cm(OH)4]<3+>
+    # Editor: Marquardt
+
+Ca2(Cm(OH)4)+3      Ca+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+Ca2(Nd(OH)4)+3      Ca+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Ca2[Cm(OH)4]<3+>
+    # Editor: Marquardt
+
+Ca3(Am(OH)6)+3      Ca+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Ca3[Cm(OH)6]<3+>
+    # Editor: Marquardt
+
+Ca3(Cm(OH)6)+3      Ca+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+Ca3(Nd(OH)6)+3      Ca+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Ca3[Cm(OH)6]<3+>
+    # Editor: Marquardt
+
+Ca+2                Cl-                 HSO4-                     -5.4670768459459E-3   0      -4.0770364736304E+1      2.40448383065729E-1     -1.72947919898972E-4   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Ca+2                Cl-                 OH-                       -3.7840579052168E-2      9.81979278970473E+1   0      1.51968273004991E-3   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Ca+2                Cl-                 SO4-2                     -1.7920500330748E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Ca+2                H+                  CO3-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Ca+2                H+                  Cl-                       -1.1909725759463E-2      1.98164994647904E+1        1.716608551326E-2      1.08083580010824E-4   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Ca+2                H+                  HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Ca+2                H+                  HSO4-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Ca+2                H+                  OH-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Ca+2                H+                  SO4-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Ca+2                Mg(OH)+             CO3-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Ca+2                Mg(OH)+             HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Ca+2                Mg(OH)+             OH-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Ca+2                Mg+2                NO3-                               -1.0963E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MUN2024
+    # Editor: Moog
+
+Ca+2                Mg+2                SiO2(OH)2-2            0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Ca+2                NO3-                Cl-                                  -5.55E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MUN2024
+    # Editor: Moog
+
+Ca+2                NO3-                SO4-2                               -5.535E-2   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MUN2024
+    # Editor: Moog
+
+Ca+2                SO4-2               HSO4-                     -1.9432695558257E-1     -1.75636872572013E+3     -7.28425100006014E+0      7.00155512658608E-3   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Ca(Am(OH)3)+2       Ca+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Ca[Cm(OH)3]<2+>
+    # Editor: Marquardt
+
+Ca(Cm(OH)3)+2       Ca+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+Ca(Nd(OH)3)+2       Ca+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Ca[Cm(OH)3]<2+>
+    # Editor: Marquardt
+
+Cd+2                Ca+2                Cl-                                 -3.212E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2024
+    # Editor: Moog
+
+Cd+2                Ca+2                SO4-2                               1.1727E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2024
+    # Editor: Moog
+
+Cd+2                Cl-                 SO4-2                                -4.63E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2024
+    # Editor: Moog
+
+Cd+2                K+                  Cl-                                 -3.826E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2024
+    # Editor: Moog
+
+Cd+2                K+                  SO4-2                                -3.17E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2024
+    # Editor: Moog
+
+Cd+2                Mg+2                Cl-                                 -3.701E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2024
+    # Editor: Moog
+
+Cd+2                Mg+2                SO4-2                               1.3094E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2024
+    # Editor: Moog
+
+Cd+2                Na+                 Cl-                                 -1.935E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2024
+    # Editor: Moog
+
+Cd+2                Na+                 SO4-2                                1.089E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2024
+    # Editor: Moog
+
+H+                  Cl-                 Al(OH)4-               0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Na+                 Cl-                 Al(OH)4-                              -4.3E-3   0                8.2841E-1               -4.7316E-3                3.3739E-6   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+K+                  Cl-                 CO3-2                                  4.0E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+Na+                 Cl-                 CO3-2                                  8.5E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+Mg+2                Cl-                 HCO3-                                 -9.6E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+Na+                 Cl-                 HCO3-                                 -1.5E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+Mg+2                Cl-                 SiO(OH)3-              0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Na+                 Cl-                 SiO(OH)3-                             -1.5E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 373.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+H+                  Cl-                 SiO(OH)3-              0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Ca+2                Cl-                 SiO2(OH)2-2                           -1.8E-2   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+K+                  Cl-                 SiO2(OH)2-2                            4.0E-3   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Mg+2                Cl-                 SiO2(OH)2-2            0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Na+                 Cl-                 SiO2(OH)2-2            0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Na+                 Cm(CO3)2-           Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FAN/KON1999
+    # Description: theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters
+    # Editor: Marquardt
+
+Na+                 Cm(CO3)3-3          Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FAN/KON1999
+    # Description: theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters
+    # Editor: Marquardt
+
+Na+                 Cm(CO3)4-5          Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FAN/KON1999
+    # Description: theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters
+    # Editor: Marquardt
+
+Cm(CO3)+            Na+                 Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: FAN/KON1999
+    # Description: theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters
+    # Editor: Marquardt
+
+Cm(NO3)2+           Mg+2                NO3-                                 3.341E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Cm(NO3)2+           Na+                 NO3-                                  -2.0E-4   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Cm(NO3)+2           Mg+2                NO3-                                -1.024E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Cm(NO3)+2           Na+                 NO3-                                -1.111E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Cm(OH)2+            Ca+2                Cl-                                    7.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Nd(OH)2<+> and Am(OH)2<+>
+    # Editor: Marquardt
+
+Cm(OH)2+            Ca+2                NO3-                                   7.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+Cm(OH)2+            Mg+2                Cl-                                    7.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from Nd(OH)2<+> and Am(OH)2<+> interaction with Ca<2+>
+    # Editor: Marquardt
+
+Cm(OH)2+            Mg+2                NO3-                                   7.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+Cm(OH)2+            Na+                 Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Nd(OH)2<+> and Am(OH)2<+>
+    # Editor: Marquardt
+
+Cm(OH)+2            Ca+2                Cl-                                    4.0E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+Cm(OH)+2            Ca+2                NO3-                                   4.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+Cm(OH)+2            Mg+2                Cl-                                    4.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from interaction with Ca<2+>
+    # Editor: Marquardt
+
+Cm(OH)+2            Mg+2                NO3-                                   4.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+Cm(OH)+2            Na+                 Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 0, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: NEC/FAN1998
+    # Editor: Marquardt
+
+Na+                 Cm(SO4)2-           Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Description: theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters
+    # Editor: Marquardt
+
+Na+                 Cm(SO4)2-           SO4-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Description: theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters
+    # Editor: Marquardt
+
+Cm(SO4)+            Na+                 Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Description: theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters
+    # Editor: Marquardt
+
+Cm(SO4)+            Na+                 SO4-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/FAN1998
+    # Description: theta(cc) and psi(cca) cannot be separated from the binary parameters beta(0) and C(phi) and are therefore set equal to 0. i.e. their effects on the trace activity coefficients are included with the binary parameters
+    # Editor: Marquardt
+
+Cm+3                Ca+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: Nd<3+>
+    # Editor: Marquardt
+
+Cm+3                K+                  Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: ALT/BRE2004
+    # Description: analogue value from: Nd<3+> and Na<+>
+    # Editor: Marquardt
+
+Cm+3                Mg+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: Nd<3+> and Ca<2+>
+    # Editor: Marquardt
+
+Cm+3                Mg+2                NO3-                   0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Cm+3                Na+                 Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: Nd<3+>
+    # Editor: Marquardt
+
+Cm+3                Na+                 NO3-                   0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+CmCl2+              Ca+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: Cm(III) data from KON/FAN1997
+    # Editor: Marquardt
+
+CmCl2+              Mg+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from interaction with Ca<2+> (Cm(III) data from KON/FAN1997)
+    # Editor: Marquardt
+
+CmCl2+              Na+                 Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+CmCl+2              Ca+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: Cm(III) data from KON/FAN1997
+    # Editor: Marquardt
+
+CmCl+2              Mg+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from interaction with Ca<2+> (Cm(III) data from KON/FAN1997)
+    # Editor: Marquardt
+
+CmCl+2              Na+                 Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+Cs+                 Ca+2                Cl-                                 -1.171E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2013
+    # Editor: Moog
+
+Cs+                 Ca+2                SO4-2                  0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 4
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2012
+    # Editor: Moog
+
+Cs+                 Cl-                 SO4-2                                1.039E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2013
+    # Editor: Moog
+
+Cs+                 K+                  Cl-                                    2.0E-4   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2013
+    # Editor: Moog
+
+Cs+                 K+                  SO4-2                                 3.06E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2013
+    # Editor: Moog
+
+Cs+                 Mg+2                Cl-                                 -1.033E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2013
+    # Editor: Moog
+
+Cs+                 Mg+2                SO4-2                               -3.584E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2013
+    # Editor: Moog
+
+Cs+                 Na+                 Cl-                                  -4.85E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2013
+    # Editor: Moog
+
+Cs+                 Na+                 SO4-2                                 -1.2E-4   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2013
+    # Editor: Moog
+
+H+                  K+                  SiO(OH)3-              0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+H+                  Mg(OH)+             CO3-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+H+                  Mg(OH)+             HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+H+                  Mg(OH)+             OH-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+H+                  Mg+2                SiO(OH)3-              0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+H+                  Na+                 SiO(OH)3-              0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Ca+2                HCO3-               CO3-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Mg+2                HCO3-               CO3-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Ca+2                HCO3-               Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+K+                  HCO3-               Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+Ca+2                HCO3-               SO4-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+K+                  HCO3-               SO4-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+K+                  HCO3-               SiO2(OH)2-2                            1.2E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Mg+2                HCO3-               SiO2(OH)2-2            0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Na+                 HCO3-               SiO2(OH)2-2                            2.0E-3   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+K+                  Ca+2                Cl-                        -4.318845586513E-2      -2.7076725039389E+1   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+K+                  Ca+2                NO3-                               -4.8027E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MUN2024
+    # Editor: Moog
+
+K+                  Ca+2                SO4-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+K+                  Cl-                 H2PO4-                              -1.199E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+K+                  Cl-                 HPO4-2                               -7.36E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+K+                  Cl-                 OH-                       -3.2270178141549E-3     -1.70410061939984E+0   0      2.02193825245054E-5   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+K+                  Cl-                 PO4-3                               -1.632E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+K+                  Cl-                 SO4-2                    -6.4651484166234E-10     -2.06379617776174E+2   0      -1.9995439509291E-3   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+K+                  H+                  Al(OH)4-               0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+K+                  H+                  CO3-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+K+                  H+                  Cl-                       -1.3194296392262E-2      4.36416345059835E+1      1.11867797582537E-1      2.12455201154609E-5   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+K+                  H+                  HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+K+                  H+                  HSO4-                     -2.1169075379348E-2   0      8.91181978952432E+0     -5.26808164050755E-2      3.89896310060737E-5   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+K+                  H+                  OH-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+K+                  H+                  SO4-2                     -5.8488136949966E-3     -4.04662041012689E+1   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+K+                  H+                  SiO2(OH)2-2            0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+K+                  HPO4-2              H2PO4-                                6.32E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+K+                  Mg+2                Cl-                       -2.1999734986016E-2      3.32111705574599E+2   0      5.37731099043839E-3      -3.7316131192495E-6   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+K+                  Mg+2                NO3-                               -3.0245E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MUN2024
+    # Editor: Moog
+
+K+                  Mg+2                SO4-2                     -4.8011889034427E-2      5.15629695110951E+3      3.57903662276745E+1     -7.95128412893139E-2      2.79662517289073E-5   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+K+                  Mg+2                SiO2(OH)2-2            0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+K+                  NO3-                Cl-                                -6.0609E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MUN2024
+    # Editor: Moog
+
+K+                  NO3-                SO4-2                                -8.99E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MUN2024
+    # Editor: Moog
+
+K+                  PO4-3               HPO4-2                              -2.975E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+K+                  SO4-2               H2PO4-                               -3.65E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+K+                  SO4-2               HPO4-2                                 1.1E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+K+                  SO4-2               OH-                       -9.7309897555057E-3     -4.20903077034097E+1   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Mg(OH)+             Mg+2                Cl-                         1.991837570531E-2        5.107566768101E+2   0        1.103159340488E-2       -9.042065336123E-6   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 393.15 K.
+    # Reference: FRE/PAN2023
+    # Editor: Freyer
+
+Mg+2                Ca+2                CO3-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Mg+2                Ca+2                Cl-                       -1.1778176199069E-2      -1.2470933044681E+0      3.89808313789163E+0     -2.56644322569006E-2      2.07555389981358E-5   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Mg+2                Ca+2                HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Mg+2                Ca+2                OH-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Mg+2                Ca+2                SO4-2                     -1.1999857492789E-2     -2.57406851925792E+3     -8.00940788261471E+0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Mg+2                Cl-                 SO4-2                      -3.999950677386E-3     -6.69971942028985E+2   0     -1.64741987010644E-2       1.4847701425221E-5   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Mg+2                H+                  Al(OH)4-               0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Mg+2                H+                  CO3-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Mg+2                H+                  Cl-                       -9.8523139895121E-3     -1.35729135486199E+3     -1.13092314703229E+1      2.92705720127488E-2     -1.11735057550063E-5     -3.36836639004149E+1
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Mg+2                H+                  HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 4
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Mg+2                H+                  HSO4-                      -1.779978591617E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Mg+2                H+                  OH-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Mg+2                H+                  SO4-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Mg+2                Mg(OH)+             CO3-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Mg+2                Mg(OH)+             HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Mg+2                Mg(OH)+             OH-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 273.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Mg+2                Mg3(OH)4+2          Cl-                         1.076194373518E-1       -3.734368880805E+6       -1.567998542039E+4        2.921826338092E+1       -1.019369372398E-2        1.665175959746E+8
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 393.15 K.
+    # Reference: FRE/PAN2023
+    # Editor: Freyer
+
+Mg+2                NO3-                Cl-                                 -4.518E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MUN2024
+    # Editor: Moog
+
+Mg+2                NO3-                SO4-2                               -9.452E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MUN2024
+    # Editor: Moog
+
+Na+                 Ca+2                CO3-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Na+                 Ca+2                Cl-                       -1.0946055909358E-3      -6.1879848457514E+3     -5.71617086090565E+1      1.73852913584701E-1     -8.72254834325576E-5   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Na+                 Ca+2                HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Na+                 Ca+2                NO3-                                -6.136E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MUN2024
+    # Editor: Moog
+
+Na+                 Ca+2                OH-                        2.5517013134504E-1   0      -1.1960108422476E+3      7.53769004251609E+0      -5.8434783691142E-3   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Na+                 Ca+2                SO4-2                     -2.4987752573267E-2      5.41223164351434E+2      5.64553123940105E+0     -1.89435536712971E-2      1.02200232966504E-5   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Na+                 Ca+2                SiO2(OH)2-2                           -5.5E-2   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Na+                 Cl-                 H2PO4-                              -1.208E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+Na+                 Cl-                 HPO4-2                               -8.83E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+Na+                 Cl-                 OH-                       -4.2736390951088E-3   0      8.28412891695231E-1     -4.73162879186962E-3      3.37394750135306E-6   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Na+                 Cl-                 PO4-3                                -2.43E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+Na+                 Cl-                 SO4-2                      1.3999831181882E-3     -1.28330056527753E+2   0     -1.44069567262012E-3   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Na+                 H+                  Al(OH)4-               0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Na+                 H+                  CO3-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Na+                 H+                  Cl-                       -2.5110229452219E-3      3.59304603523964E+0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Na+                 H+                  HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Na+                 H+                  HSO4-                     -1.4632734018883E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Na+                 H+                  OH-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Na+                 H+                  SO4-2                      1.3076549062069E-2      2.47898831439052E+0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Na+                 HPO4-2              H2PO4-                               3.781E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+Na+                 HSO4-               SO4-2                      5.2319950057418E-3      1.98971943953335E+1   0      1.40453143303867E-4   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Na+                 K+                  CO3-2                                  3.0E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+Na+                 K+                  Cl-                       -1.7999783489825E-3   0   0      2.04660638523062E-5   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Na+                 K+                  H2PO4-                              -1.143E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+Na+                 K+                  HCO3-                                 -3.0E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+Na+                 K+                  HPO4-2                                 9.9E-4   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+Na+                 K+                  NO3-                                -2.832E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MUN2024
+    # Editor: Moog
+
+Na+                 K+                  OH-                        -3.708819758295E-3      -1.8402481604426E+2   0     -1.60450254014072E-3   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Na+                 K+                  SO4-2                     -9.9998797274884E-3   0   0      3.53976442600277E-4   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Na+                 K+                  SiO(OH)3-                             -3.0E-3   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Na+                 K+                  SiO2(OH)2-2                            3.0E-3   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Na+                 Mg(OH)+             CO3-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Na+                 Mg(OH)+             Cl-                         4.822779694775E-2   0   0        8.022120365482E-4   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 313.15 K.
+    # Reference: FRE/PAN2023
+    # Editor: Freyer
+
+Na+                 Mg(OH)+             HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Na+                 Mg(OH)+             OH-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Na+                 Mg3(OH)4+2          Cl-                         1.131744985573E-1   0   0        -1.12213467781E-3   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 313.15 K.
+    # Reference: FRE/PAN2023
+    # Editor: Freyer
+
+Na+                 Mg+2                CO3-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Na+                 Mg+2                Cl-                       -1.1999856476722E-2   0      6.18873156654038E-1     -3.67854306693126E-3      2.64366820374045E-6   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Na+                 Mg+2                HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Na+                 Mg+2                NO3-                                 -1.89E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MUN2024
+    # Editor: Moog
+
+Na+                 Mg+2                OH-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Na+                 Mg+2                SO4-2                     -1.4999819688294E-2      -7.3684333778339E+1   0     -7.80389614047748E-4   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Na+                 Mg+2                SiO2(OH)2-2            0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Na+                 NO3-                Cl-                                -6.8049E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MUN2024
+    # Editor: Moog
+
+Na+                 NO3-                SO4-2                                 -4.0E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MUN2024
+    # Editor: Moog
+
+Na+                 PO4-3               HPO4-2                                2.07E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+Na+                 SO4-2               H2PO4-                              -1.414E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+Na+                 SO4-2               HPO4-2                              -1.911E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+Na+                 SO4-2               OH-                       -1.1499420768239E-2     -2.55446774430212E+0   0      1.47735612003127E-4   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 393.15 K.
+    # Reference: VOI2020
+    # Editor: Freyer
+
+Na+                 SO4-2               PO4-3                              -2.8058E-1   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH/MUN2015
+    # Editor: Moog
+
+Na+                 SO4-2               PbCl4-2                              -3.86E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG1999
+    # Editor: Moog
+
+Nd(NO3)2+           Mg+2                NO3-                                 3.341E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Nd(NO3)2+           Na+                 NO3-                                  -2.0E-4   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Nd(NO3)+2           Mg+2                NO3-                                -1.024E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Nd(NO3)+2           Na+                 NO3-                                -1.111E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Nd(OH)2+            Ca+2                Cl-                                    7.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: value from TRLFS Cm(OH)2<+> data
+    # Editor: Marquardt
+
+Nd(OH)2+            Ca+2                NO3-                                   7.0E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+Nd(OH)2+            Mg+2                Cl-                                    7.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: value from TRLFS Cm data
+    # Editor: Marquardt
+
+Nd(OH)2+            Mg+2                NO3-                                   7.0E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+Nd(OH)2+            Na+                 Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: value from TRLFS Cm data
+    # Editor: Marquardt
+
+Ca+2                Nd(OH)4-            Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Am(OH)4<-> interaction
+    # Editor: Marquardt
+
+K+                  Nd(OH)4-            Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Am(OH)4<-> interaction with Na<+>
+    # Editor: Marquardt
+
+K+                  Nd(OH)4-            OH-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Am(OH)4<-> interaction with Na<+>
+    # Editor: Marquardt
+
+Mg+2                Nd(OH)4-            Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Am(OH)4<-> interaction with Ca<2+>
+    # Editor: Marquardt
+
+Na+                 Nd(OH)4-            Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Am(OH)4<-> interaction
+    # Editor: Marquardt
+
+Na+                 Nd(OH)4-            OH-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Am(OH)4<-> interaction
+    # Editor: Marquardt
+
+Nd(OH)+2            Ca+2                Cl-                                    4.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Cm(OH)<2+> and Am(OH)<2+>
+    # Editor: Marquardt
+
+Nd(OH)+2            Ca+2                NO3-                                   4.0E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+Nd(OH)+2            Mg+2                Cl-                                    4.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Cm(OH)<2+> and Am(OH)<2+> interaction with Ca<2+>
+    # Editor: Marquardt
+
+Nd(OH)+2            Mg+2                NO3-                                   4.0E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HER/GAO2015
+    # Editor: Kiefer
+
+Nd(OH)+2            Na+                 Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Cm(OH)<2+> and Am(OH)<2+>
+    # Editor: Marquardt
+
+Nd+3                Ca+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Editor: Marquardt
+
+Nd+3                K+                  Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: ALT/BRE2004
+    # Description: analogue value from: Nd<3+> and Na<+>
+    # Editor: Marquardt
+
+Nd+3                Mg+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Description: analogue value from: Nd<3+> and Ca<2+>
+    # Editor: Marquardt
+
+Nd+3                Mg+2                NO3-                   0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+Nd+3                Na+                 Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Editor: Marquardt
+
+Nd+3                Na+                 NO3-                   0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: DOS/HAU2026
+    # Editor: Kiefer
+
+NdCl2+              Ca+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: CmCl2<+>. Cm(III)-data from KON/FAN1997
+    # Editor: Marquardt
+
+NdCl2+              Mg+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: CmCl2<+> and Ca<2+>. Cm(III) data from KON/FAN1997
+    # Editor: Marquardt
+
+NdCl2+              Na+                 Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: CmCl2<+>. Cm(III)-data from KON/FAN1997
+    # Editor: Marquardt
+
+NdCl+2              Ca+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: CmCl<2+>. Cm(III)-data from KON/FAN1997
+    # Editor: Marquardt
+
+NdCl+2              Mg+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: CmCl<2+> interaction with Ca<2+>. Cm(III) data from KON/FAN1997
+    # Editor: Marquardt
+
+NdCl+2              Na+                 Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/ALT2009
+    # Additional reference: KON/FAN1997
+    # Description: analogue value from: CmCl<2+>. Cm(III)-data from KON/FAN1997
+    # Editor: Marquardt
+
+Na+                 NpO2(CO3)2-3        Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Editor: Marquardt
+
+Na+                 NpO2(CO3)3-5        CO3-2                  0   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Description: Analogy to K<+>
+    # Editor: Marquardt
+
+Na+                 NpO2(CO3)3-5        Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Editor: Marquardt
+
+Na+                 NpO2(CO3)-          Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Editor: Marquardt
+
+K+                  NpO2(OH)2-          Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Editor: Marquardt
+
+Mg+2                NpO2(OH)2-          Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Editor: Marquardt
+
+Na+                 NpO2(OH)2-          Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Editor: Marquardt
+
+NpO2+               K+                  Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Editor: Marquardt
+
+NpO2+               Mg+2                Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 2
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Editor: Marquardt
+
+NpO2+               Na+                 Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC1997
+    # Additional reference: FAN/NEC1995
+    # Editor: Marquardt
+
+Ca+2                OH-                 CO3-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+H+                  OH-                 CO3-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+K+                  OH-                 CO3-2                                 -1.0E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+Mg(OH)+             OH-                 CO3-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Mg+2                OH-                 CO3-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Na+                 OH-                 CO3-2                              -1.2629E-2   0   0               -2.4055E-5   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Mg+2                OH-                 Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+Ca+2                OH-                 HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+H+                  OH-                 HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+K+                  OH-                 HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+Mg(OH)+             OH-                 HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Mg+2                OH-                 HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Na+                 OH-                 HCO3-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: VOI2023
+    # Editor: Freyer
+
+Ca+2                OH-                 SO4-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+Mg+2                OH-                 SO4-2                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+K+                  OH-                 SiO2(OH)2-2                           -1.0E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Na+                 OH-                 SiO2(OH)2-2                           -1.7E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+K+                  SO4-2               Al(OH)4-                              -9.7E-3                -4.209E+1   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Mg+2                SO4-2               Al(OH)4-               0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Na+                 SO4-2               Al(OH)4-                             -1.15E-2               -2.5545E+0   0                1.4774E-4   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 423.15 K.
+    # Reference: MIR2023
+    # Editor: Miron
+
+K+                  SO4-2               CO3-2                                 -9.0E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+Na+                 SO4-2               CO3-2                                 -5.0E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+Mg+2                SO4-2               HCO3-                                -1.61E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+Na+                 SO4-2               HCO3-                                 -5.0E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAR/MOL1984
+    # Editor: Freyer
+
+K+                  SO4-2               SiO(OH)3-                             -5.0E-3   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Mg+2                SO4-2               SiO(OH)3-              0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Na+                 SO4-2               SiO(OH)3-                             -5.0E-3   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+K+                  SO4-2               SiO2(OH)2-2                           -9.0E-3   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Na+                 SO4-2               SiO2(OH)2-2                           -5.0E-3   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+K+                  SeO3-2              Cl-                                   2.54E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG/MOO2012
+    # Editor: Bok
+
+Na+                 SeO3-2              Cl-                    0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG/MOO2012
+    # Editor: Bok
+
+Na+                 K+                  SeO3-2                                 8.5E-4   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG/MOO2012
+    # Editor: Bok
+
+K+                  SeO3-2              SO4-2                              -1.0277E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG/MOO2012
+    # Editor: Bok
+
+Na+                 SeO3-2              SO4-2                               -1.978E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG/MOO2012
+    # Editor: Bok
+
+Ca+2                SeO4-2              Cl-                                   1.52E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: BIS/HAG2016
+    # Editor: Bok
+
+K+                  SeO4-2              Cl-                    0   0   0               9.54329E-5   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: BIS/HAG2016
+    # Description: All ternary interaction coefficients for the systems Na,K,Mg - Cl,SO4,SeO4 - H2O were derived from constructed isoactivity lines.
+    # Editor: Bok
+
+Mg+2                SeO4-2              Cl-                                   9.39E-3   0   0              -2.04945E-4   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: BIS/HAG2016
+    # Description: All ternary interaction coefficients for the systems Na,K,Mg - Cl,SO4,SeO4 - H2O were derived from constructed isoactivity lines.
+    # Editor: Bok
+
+Na+                 SeO4-2              Cl-                    0   0   0               5.72674E-5   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: BIS/HAG2016
+    # Description: All ternary interaction coefficients for the systems Na,K,Mg - Cl,SO4,SeO4 - H2O were derived from constructed isoactivity lines.
+    # Editor: Bok
+
+K+                  Mg+2                SeO4-2                              -4.568E-2   0   0               5.21087E-4   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: BIS/HAG2016
+    # Description: All ternary interaction coefficients for the systems Na,K,Mg - Cl,SO4,SeO4 - H2O were derived from constructed isoactivity lines.
+    # Editor: Bok
+
+Na+                 Ca+2                SeO4-2                               -4.89E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: BIS/HAG2016
+    # Editor: Bok
+
+Na+                 K+                  SeO4-2                               1.949E-2   0   0              -3.26817E-4   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: BIS/HAG2016
+    # Description: All ternary interaction coefficients for the systems Na,K,Mg - Cl,SO4,SeO4 - H2O were derived from constructed isoactivity lines.
+    # Editor: Bok
+
+Na+                 Mg+2                SeO4-2                              -1.557E-2   0   0              -3.67813E-5   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: BIS/HAG2016
+    # Description: All ternary interaction coefficients for the systems Na,K,Mg - Cl,SO4,SeO4 - H2O were derived from constructed isoactivity lines.
+    # Editor: Bok
+
+K+                  SeO4-2              SO4-2                                 7.28E-3   0   0                2.1818E-3   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: BIS/HAG2016
+    # Description: All ternary interaction coefficients for the systems Na,K,Mg - Cl,SO4,SeO4 - H2O were derived from constructed isoactivity lines.
+    # Editor: Bok
+
+Mg+2                SeO4-2              SO4-2                                 6.05E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: BIS/HAG2016
+    # Description: All ternary interaction coefficients for the systems Na,K,Mg - Cl,SO4,SeO4 - H2O were derived from constructed isoactivity lines.
+    # Editor: Bok
+
+Na+                 SeO4-2              SO4-2                                2.598E-2   0   0               2.75496E-4   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: BIS/HAG2016
+    # Description: All ternary interaction coefficients for the systems Na,K,Mg - Cl,SO4,SeO4 - H2O were derived from constructed isoactivity lines.
+    # Editor: Bok
+
+K+                  SiO(OH)3-           SiO2(OH)2-2                            1.2E-2   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Mg+2                SiO(OH)3-           SiO2(OH)2-2            0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Na+                 SiO(OH)3-           SiO2(OH)2-2                            2.0E-3   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+K+                  SiO2(OH)2-2         Al(OH)4-               0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Mg+2                SiO2(OH)2-2         Al(OH)4-               0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Na+                 SiO2(OH)2-2         Al(OH)4-               0   0   0   0   0   0
+    # Evaluation ip class: 4, data quality: 5
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MIR2023
+    # Editor: Miron
+
+Sr+2                Ca+2                Cl-                                -8.1237E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH2016
+    # Editor: Moog
+
+Sr+2                K+                  Cl-                                 -2.144E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH2016
+    # Editor: Moog
+
+Sr+2                Mg+2                Cl-                                -3.1398E-3   0   0   0   0   0
+    # Evaluation ip class: 2, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH2016
+    # Editor: Moog
+
+Sr+2                Na+                 Cl-                                -1.4575E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH2016
+    # Editor: Moog
+
+Sr+2                Na+                 SO4-2                  0   0   0   0   0   0
+    # Evaluation ip class: 3, data quality: 3
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: SCH2016
+    # Description: The coefficient psi(Na-Sr-SO4) is set to zero.
+    # Editor: Moog
+
+Ca+2                TcO4-               Cl-                                   -3.3E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/KON1998
+    # Editor: Kiefer
+
+K+                  TcO4-               Cl-                                   -1.1E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/KON1998
+    # Editor: Kiefer
+
+Mg+2                TcO4-               Cl-                                  -1.15E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/KON1998
+    # Editor: Kiefer
+
+Na+                 TcO4-               Cl-                                   -8.5E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/KON1998
+    # Additional reference: KON/NEC1997
+    # Editor: Kiefer
+
+K+                  Ca+2                TcO4-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/KON1998
+    # Editor: Kiefer
+
+K+                  Mg+2                TcO4-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/KON1998
+    # Editor: Kiefer
+
+Mg+2                Ca+2                TcO4-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/KON1998
+    # Editor: Kiefer
+
+Na+                 Ca+2                TcO4-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/KON1998
+    # Editor: Kiefer
+
+Na+                 K+                  TcO4-                  0   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/KON1998
+    # Editor: Kiefer
+
+Na+                 Mg+2                TcO4-                                 -2.0E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: NEC/KON1998
+    # Editor: Kiefer
+
+Na+                 Th(CO3)5-6          Cl-                                    3.0E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MAR/GAO2014
+    # Additional reference: FEL/RAI1997
+    # Editor: Marquardt
+
+Th+4                H+                  Cl-                                    8.0E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MAR/GAO2014
+    # Additional reference: RAI/MOO2000
+    # Editor: Marquardt
+
+Th+4                Na+                 Cl-                                    2.1E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: MAR/GAO2014
+    # Additional reference: RAI/MOO2000
+    # Editor: Marquardt
+
+UO2+2               Mg+2                Cl-                                   -7.2E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Editor: Richter
+
+UO2+2               Na+                 Cl-                                   -1.0E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: YAL/CEV2019
+    # Editor: Richter
+
+Zn+2                Ca+2                Cl-                                 -4.623E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2022
+    # Editor: Moog
+
+Zn+2                Ca+2                SO4-2                                 7.29E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2022
+    # Editor: Moog
+
+Zn+2                Cl-                 SO4-2                                 2.72E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2022
+    # Editor: Moog
+
+Zn+2                K+                  Cl-                                  -5.68E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2022
+    # Editor: Moog
+
+Zn+2                K+                  SO4-2                                8.863E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2022
+    # Editor: Moog
+
+Zn+2                Mg+2                Cl-                                 -2.458E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2022
+    # Editor: Moog
+
+Zn+2                Mg+2                SO4-2                               2.2435E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2022
+    # Editor: Moog
+
+Zn+2                Na+                 Cl-                                 -2.583E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2022
+    # Editor: Moog
+
+Zn+2                Na+                 SO4-2                                 5.26E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: HAG2022
+    # Editor: Moog
+
+# #### all zeta coefficients ###################################################
+-ZETA
+O2                  Ca+2                Cl-                                 -1.269E-2                 2.449E+1   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 278.15 K - 318.15 K.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  H+                  HSO4-                               -2.472E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 288.15 K - 310.2 K.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  K+                  CO3-2                               -9.697E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  K+                  Cl-                                 -1.711E-2                 7.477E+2                 2.464E+0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 278.15 K - 318.15 K.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  K+                  H2PO4-                              -1.678E-1   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  K+                  HPO4-2                              -9.593E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  K+                  HSO4-                                7.411E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  K+                  SO4-2                               -1.618E-1                 1.647E+2   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 278.15 K - 318.15 K.
+    # Reference: BOK/MOO2023
+    # Description: Typo in publication: X0 term must be 0.1618  0.078, not 0.1575  0.0688, X1 term must be 164.7  102  , not 183.5  70.3!
+    # Editor: Bok
+
+O2                  Mg+2                Cl-                                 -6.612E-3                -8.755E+2                -2.974E+0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 278.15 K - 318.15 K.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  Mg+2                SO4-2                               -5.115E-2                 5.181E+3                 1.686E+1   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 278.15 K - 318.15 K.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  Na+                 CO3-2                                7.437E-3   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  Na+                 Cl-                                 -3.767E-3                -1.075E+3                -3.663E+0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 318.15 K.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  Na+                 OH-                    0                 -4.07E+1   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 288.15 K - 323.15 K.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  Na+                 PO4-3                                -5.94E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  Na+                 SO4-2                                -3.81E-2                 4.216E+3                 1.349E+1   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 278.15 K - 318.15 K.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+# #### all eta coefficients ####################################################
+-ETA
+O2                  Cl-                 SO4-2                               -1.445E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+O2                  Na+                 Mg+2                                -1.753E-2   0   0   0   0   0
+    # Evaluation ip class: 1, data quality: 1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: BOK/MOO2023
+    # Editor: Bok
+
+
+# ###### Additional information by THEREDA #####################################
+# ###### SOLID-SOLUTIONS BLOCK #################################################
+# Template for solid ideal and non-ideal solutions, to be used for scripts with PHREEQC
+# SOLID_SOLUTIONS 1
+# (Cs,Na)Cl:H2O(cr) # ideal
+# -comp CsCl(cr) 0.0
+# -comp CsNa2Cl3:2H2O(cr) 0.0
+
+# SOLID_SOLUTIONS 2
+# (Zn,Mg)(SO4)2:7H2O(s) # ideal
+# -comp Epsomite 0.0
+# -comp Goslarite 0.0
+
+# SOLID_SOLUTIONS 3
+# CNASH_ss # ideal
+# -comp CNASH_TobH 0.0
+# -comp CNASH_T5C 0.0
+# -comp CNASH_T2C 0.0
+# -comp CNASH_INFCN 0.0
+# -comp CNASH_5CA 0.0
+# -comp CNASH_INFCA 0.0
+# -comp CNASH_5CNA 0.0
+# -comp CNASH_INFCNA 0.0
+
+# SOLID_SOLUTIONS 4
+# CSH-II_ss # ideal
+# -comp CSH-II_Tob 0.0
+# -comp CSH-II_Jen 0.0
+
+# SOLID_SOLUTIONS 5
+# CSH3T_ss # ideal
+# -comp CSH3T_T5C 0.0
+# -comp CSH3T_TobH 0.0
+# -comp CSH3T_T2C 0.0
+
+# SOLID_SOLUTIONS 6
+# CSHQ_ss # ideal
+# -comp CSHQ_TobH 0.0
+# -comp CSHQ_KSiOH 0.0
+# -comp CSHQ_JenH 0.0
+# -comp CSHQ_TobD 0.0
+# -comp CSHQ_NaSiOH 0.0
+# -comp CSHQ_JenD 0.0
+
+# SOLID_SOLUTIONS 7
+# ECSH-1_ss # ideal
+# -comp ECSH-1_NaSH 0.0
+# -comp ECSH-1_KSH 0.0
+# -comp ECSH-1_TobCa 0.0
+# -comp ECSH-1_SH 0.0
+
+# SOLID_SOLUTIONS 8
+# ECSH-2_ss # ideal
+# -comp ECSH-2_TobCa 0.0
+# -comp ECSH-2_KSH 0.0
+# -comp ECSH-2_NaSH 0.0
+# -comp ECSH-2_JenCa 0.0
+
+# SOLID_SOLUTIONS 9
+# Ettringite-H2O_ss # ideal
+# -comp Ettringite-H2O_ettringite32 0.0
+# -comp Ettringite-H2O_ettringite30 0.0
+
+# SOLID_SOLUTIONS 10
+# MSH_ss # ideal
+# -comp MSH_M075SH 0.0
+# -comp MSH_M15SH 0.0
+
+# SOLID_SOLUTIONS 11
+# Mg-Calcite # non-ideal
+# -comp1 Calcite 0.0
+# -comp2 Magnesite_ss(cr) 0.0
+# -Gugg_nondim -1.845 0
+
+# SOLID_SOLUTIONS 12
+# MgAl-OH-LDH_ss # ideal
+# -comp MgAl-OH-LDH_M4AH10 0.0
+# -comp MgAl-OH-LDH_M6AH12 0.0
+# -comp MgAl-OH-LDH_M8AH14 0.0
+
+# SOLID_SOLUTIONS 13
+# SO4-CO3-AFt_ss # non-ideal
+# -comp1 SO4-CO3-AFt_tricarboalu03 0.0
+# -comp2 SO4-CO3-AFt_ettringite03 0.0
+# -Gugg_nondim 1.67 -0.946
+
+# SOLID_SOLUTIONS 14
+# SO4-OH-AFm_ss # non-ideal
+# -comp1 SO4-OH-AFm_C4AH13 0.0
+# -comp2 SO4-OH-AFm_monosulphate12 0.0
+# -Gugg_nondim 0.188 -2.49
+
+# SOLID_SOLUTIONS 15
+# Straetlingite-H2O_ss # ideal
+# -comp Straetlingite-H2O_straetlingite8 0.0
+# -comp Straetlingite-H2O_straetlingite7 0.0
+
+
+# #### Disabled phase constituents #############################################
+# NpO2(CO3)2(OH)<4->
+# Disabled. Please see Description for details.
+#     NpO2(CO3)2(OH)-4 + H+ = 2 CO3-2 + H2O + NpO2+
+    # Description: No Pitzer parameters available, but species important for modelling at high pH values and high CO2 partial pressures
+    # Editor: Marquardt
+#     log_k     5.306
+    # Evaluation data class: 1, data quality: 2
+    # Reference: GUI/FAN2003
+    # Description: original reaction: NpO2(CO3)3<5-> + OH<->  =  NpO2(CO3)2OH<4-> + CO3<2->, logK298 = 3.195 +- 1.164
+
+# Cm(HCO3)<2+>
+# Disabled. Please see Description for details.
+#     Cm(HCO3)+2 = CO3-2 + Cm+3 + H+
+    # Description: excluded from the data block, because it not considered in the current Pitzer model
+    # Original equation: Cm<3+> + HCO3<-> = CmHCO3<2+>. log K=3.1 (GUI/FAN2003)
+    # Editor: Marquardt
+#     log_k     -13.428
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Description: original equation: Cm<3+> + HCO3<-> = CmHCO3<2+>. log K=3.1 (GUI/FAN2003)
+
+# Pb(CO3)<0>
+# Disabled. Please see Description for details.
+#     Pb(CO3) = CO3-2 + Pb+2
+    # Description: Applicability for calculations for high-saline solutions to be determined
+    # Editor: Moog
+#     log_k     -7.12
+    # Evaluation data class: 1, data quality: 2
+    # Reference: MOO2022
+    # Description: Derived in conjunction with logK(Cerussite)
+
+# TcCl6<2->
+# Disabled. Please see Description for details.
+#     TcCl6-2 + 3 H2O = 6 Cl- + 4 H+ + TcO(OH)2
+    # Description: thermodynamic data not welll known!
+    # Editor: Kiefer
+#     log_k     -1.314
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HES/XIA2004
+
+# (UO2)2(CO3)(OH)3<->
+# Disabled. Please see Description for details.
+#     (UO2)2(CO3)(OH)3- + 3 H+ = CO3-2 + 3 H2O + 2 UO2+2
+    # Description: Pcon is currently excluded from the data block because no Pitzer parameters available! Admission in the users sole discretion!
+    # Original equation: CO2(g)+4H2O(l)+2UO2<2+> = 5H<+> + (UO2)2CO3(OH)3<->
+    # Editor: Richter
+#     log_k     0.855
+    # Evaluation data class: 1, data quality: 3
+    # Reference: GUI/FAN2003
+    # Description: original value logK=-19.01+-0.50; no Pitzer parameters available! Admission in the users sole discretion!
+
+# Sr[UO2(CO3)3]<2->
+# Disabled. Please see Description for details.
+#     Sr(UO2(CO3)3)-2 = 3 CO3-2 + Sr+2 + UO2+2
+    # Editor: Bok
+#     log_k     -25.9
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GRE/GAO2020
+    # Description: no Pitzer parameters available, existence of this species is clearly acknowledged
+
+# Ca2[UO2(CO3)3]<0>
+# Disabled. Please see Description for details.
+#     Ca2(UO2(CO3)3) = 3 CO3-2 + 2 Ca+2 + UO2+2
+    # Description: Pcon is excluded from the data block because no Pitzer parameters available, experiments at low ionic strength, but species is nevertheless important for modeling [GEI/AMA2008]
+    # Editor: Richter
+#     log_k     -30.8
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GRE/GAO2020
+    # Description: no Pitzer parameters available, existence of this species is clearly acknowledged
+
+# Pb(CO3)2<2->
+# Disabled. Please see Description for details.
+#     Pb(CO3)2-2 = 2 CO3-2 + Pb+2
+    # Description: Applicability for calculations for high-saline solutions to be determined
+    # Editor: Moog
+#     log_k     -10.21
+    # Evaluation data class: 1, data quality: 2
+    # Reference: MOO2022
+    # Description: Derived in conjunction with logK(Cerussite)
+
+# Sr2[UO2(CO3)3]<0>
+# Disabled. Please see Description for details.
+#     Sr2(UO2(CO3)3) = 3 CO3-2 + 2 Sr+2 + UO2+2
+    # Description: Pcon is excluded from the data block because no Pitzer parameters available, experiments at low ionic strength, but species is nevertheless important for modeling
+    # Editor: Bok
+#     log_k     -29.7
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GRE/GAO2020
+    # Description: no Pitzer parameters available, existence of this species is clearly acknowledged
+
+# NpO2(SO4)<->
+# Disabled. Please see Description for details.
+#     NpO2(SO4)- = NpO2+ + SO4-2
+    # Description: No Pitzer parameter available!
+    # Editor: Marquardt
+#     log_k     -0.44
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+# Tc(CO3)(OH)3<->
+# Disabled. Please see Description for details.
+#     Tc(CO3)(OH)3- = CO3-2 + H+ + TcO(OH)2
+    # Description: thermodynamic data not welll known!
+    # Editor: Kiefer
+#     log_k     -10.955
+    # Evaluation data class: 1, data quality: 1
+    # Reference: RAR/RAN1999
+
+# Np(CO3)4<4->
+# Disabled. Please see Description for details.
+#     Np(CO3)4-4 = 4 CO3-2 + Np+4
+    # Description: PCon is currently excluded!
+    # Original equation: 4 CO3<2-> + 2H2O(l) + NpO2(am, hyd) --> Np(CO3)4<4-> + 4 OH<->; logK = -17.79
+    # Editor: Marquardt
+#     log_k     -38.91
+    # Evaluation data class: 1, data quality: 3
+    # Reference: GUI/FAN2003
+
+# TcCl4<0>
+# Disabled. Please see Description for details.
+#     TcCl4 + 3 H2O = 4 Cl- + 4 H+ + TcO(OH)2
+    # Description: thermodynamic data not welll known!
+    # Editor: Kiefer
+#     log_k     -5.618
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HES/XIA2004
+
+# Ca[UO2(CO3)3]<2->
+# Disabled. Please see Description for details.
+#     Ca(UO2(CO3)3)-2 = 3 CO3-2 + Ca+2 + UO2+2
+    # Description: Pcon is excluded from the data block because no Pitzer parameters available, experiments at low ionic strength, but species is nevertheless important for modeling [GEI/AMA2008]
+    # Editor: Richter
+#     log_k     -27.0
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GRE/GAO2020
+    # Description: no Pitzer parameters available, but existence of this species is clearly acknowledged
+
+# Mg[UO2(CO3)3]<2->
+# Disabled. Please see Description for details.
+#     Mg(UO2(CO3)3)-2 = 3 CO3-2 + Mg+2 + UO2+2
+    # Description: Pcon excluded from the data block, no Pitzer parameters available, experiments at low IS, but species nevertheless important for modeling, admission in the users sole discretion
+    # Editor: Richter
+#     log_k     -26.29
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GRE/GAO2020
+    # Description: no Pitzer parameters available, existence of this species is clearly acknowledged
+
+# AlSO4<+>
+# Disabled. Please see Description for details.
+#     AlSO4+ + 4 H2O = Al(OH)4- + 4 H+ + SO4-2
+    # Editor: Miron
+#     log_k     -26.778887453151
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+#     -analytical_expression               8.86135E+1   0            -1.2390215E+4     -2.98392999911219E+1   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: MAT/LOT2007
+
+# Al(SO4)2<->
+# Disabled. Please see Description for details.
+#     Al(SO4)2- + 4 H2O = Al(OH)4- + 4 H+ + 2 SO4-2
+    # Editor: Miron
+#     log_k     -28.780499454199
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+#     -analytical_expression              1.582422E+2   0            -1.5847288E+4     -5.41014999938089E+1   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: MAT/LOT2007
+
+# Am(HCO3)<2+>
+# Disabled. Please see Description for details.
+#     Am(HCO3)+2 = Am+3 + CO3-2 + H+
+    # Description: excluded from the data block, because it not considered in the current Pitzer model
+    # Original equation: Am<3+> + HCO3<-> = AmHCO3<2+>. log K=3.1 (GUI/FAN2003)
+    # Editor: Marquardt
+#     log_k     -13.428
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Additional reference: ALT/BRE2004
+    # Description: original equation: Am<3+> + HCO3<-> = AmHCO3<2+>. log K=3.1 (GUI/FAN2003)
+
+# Tc(CO3)(OH)2<0>
+# Disabled. Please see Description for details.
+#     Tc(CO3)(OH)2 + H2O = CO3-2 + 2 H+ + TcO(OH)2
+    # Description: thermodynamic data not welll known!
+    # Editor: Kiefer
+#     log_k     -19.255
+    # Evaluation data class: 1, data quality: 1
+    # Reference: RAR/RAN1999
+
+# Al(OH)6SiO<->
+# Disabled. Please see Description for details.
+#     Al(OH)6SiO- + H2O = Al(OH)4- + Si(OH)4
+    # Editor: Miron
+#     log_k     -3.6
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+#     -analytical_expression   0   0              -1.07334E+3   0   0   0 
+    # Evaluation data class: 1, data quality: 4
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: MAT/LOT2007
+
+# (UO2)3O(OH)2(HCO3)<+>
+# Disabled. Please see Description for details.
+#     (UO2)3O(OH)2(HCO3)+ + 3 H+ = CO3-2 + 3 H2O + 3 UO2+2
+    # Description: Pcon is currently excluded from the data block because no Pitzer parameters available! Admission in the users sole discretion!
+    # Original equation: CO2(g)+4H2O(l)+3UO2<2+> = 5H<+> + (UO2)3CO3(OH)3<->
+    # Editor: Richter
+#     log_k     -0.655
+    # Evaluation data class: 1, data quality: 3
+    # Reference: GUI/FAN2003
+    # Description: no Pitzer parameters available! Admission in the users sole discretion!
+
+# (UO2)11(CO3)6(OH)12<2->
+# Disabled. Please see Description for details.
+#     (UO2)11(CO3)6(OH)12-2 + 12 H+ = 6 CO3-2 + 12 H2O + 11 UO2+2
+    # Description: Pcon is currently excluded from the data block because no Pitzer parameters available! Admission in the users sole discretion!
+    # Original equation: 6CO2(g)+18H2O(l)+11UO2<2+> = 24H<+> + (UO2)11(CO3)6(OH)12<2->
+    # Editor: Richter
+#     log_k     -36.42
+    # Evaluation data class: 1, data quality: 3
+    # Reference: GUI/FAN2003
+    # Description: no Pitzer parameters available! Admission in the users sole discretion! original reaction 6CO2(g)+18H2O+11UO2<2+> = 24H<+> + (UO2)11(CO3)6(OH)12<2->, original value -72.502.00
+
+# (CdCl2)3:(Cd(OH2))5(cr)
+# Disabled. Please see Description for details.
+    # Description: Stable at about 0.0001 to 0.01 M and pH7-8 .5 (Possibly conversion rate too small). Also observed in the corrosion of Cd.
+#     Cd8Cl6(OH)10 + 10 H+ = 8 Cd+2 + 6 Cl- + 10 H2O
+    # Original equation: 8Cd<2+>+6Cl<->+10OH<->=3CdCl2:5Cd(OH)2
+    # Editor: Moog
+#     log_k     93.2
+    # Evaluation data class: 1, data quality: 3
+    # Reference: FEI/REI1951
+    # Description: Original LOGK298 for dissolution reaction = -46.8
+
+# (PbO)Pb(OH)2(s)
+# Disabled. Please see Description for details.
+#     (PbO)Pb(OH)2 + 4 H+ = 3 H2O + 2 Pb+2
+    # Description: It is questionable whether (PbO)Pb(OH)2(s) constitutes an equilibrium phase. It can be synthesized, but upon aging it may lose water to form evantually PbO. It is therefore disabled.
+    # Editor: Moog
+#     log_k     -1.86
+    # Evaluation data class: 1, data quality: 2
+    # Reference: MOO2022
+
+# Am(OH)3(cr)
+# Disabled because no reversible thermodynamic equilibrium is expected.
+#     Am(OH)3 + 3 H+ = Am+3 + 3 H2O
+    # Editor: Marquardt
+#     log_k     15.6
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+    # Additional reference: NEC/ALT2009
+
+# Am2(CO3)3_hyd(am)
+# Disabled because no reversible thermodynamic equilibrium is expected.
+#     Am2(CO3)3 = 2 Am+3 + 3 CO3-2
+    # Editor: Marquardt
+#     log_k     -33.4
+    # Evaluation data class: 1, data quality: 2
+    # Reference: GUI/FAN2003
+
+# C2AH8
+# Disabled. Please see Description for details.
+    # Description: Metastable compared with Hydrogarnet.
+#     Ca2Al2(OH)10:3H2O + 2 H+ = 2 Al(OH)4- + 2 Ca+2 + 5 H2O
+    # Description: CEMDATA07, obsolete, deactivated. Original reaction from CEMDATA07, LOGK298 = -13.56
+    # Original equation: Ca2Al2(OH)10:3H2O(cr) = 2 Ca<2+> + 2 Al(OH)4<-> + 2 OH<-> + 3 H2O(l)
+    # Editor: Miron
+#     log_k     14.440441940697
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+#     -analytical_expression               1.47897E+1   0             3.4361229E+3     -4.79870016046915E+0   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: JAC2009
+    # Description: Stability range: MAT/LOT2007: Seems to be favored at low T (around 5C).  LOT/MAT2008: Metastable at 25C, can persist for long time and is only slowly converted to the stable C3AH6 (hydrogranet), at 50C conversion within hours or days.
+
+# CSH(0.8)
+# Disabled. Please see Description for details.
+    # Description: Representative phase for low-Ca CSH.
+#     Ca0.8SiO2.8:1.6H2O + 1.6 H+ = 0.8 Ca+2 + 0.4 H2O + Si(OH)4
+    # Description: CEMDATA07, obsolete, deactivated
+    # Editor: Miron
+#     log_k     10.729823612276
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+#     -analytical_expression                1.2514E+0   0              2.825992E+3   0   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: JAC2009
+    # Description: Stability range: LOT/MAT2008: C-S-H phases metastable w.r. to jennite, tobermorite or afwillite, but even at 85C, C-S-H has been found to be only partially crystallized (bulk solubility still dominated by gel present).
+
+# CSH(1.1)
+# Disabled. Please see Description for details.
+    # Description: Representative phase for medium-Ca CSH.
+#     Ca1.1SiO3.1:2.2H2O + 2.2 H+ = 1.1 Ca+2 + 1.3 H2O + Si(OH)4
+    # Description: CEMDATA07, obsolete, deactivated
+    # Editor: Miron
+#     log_k     16.81973057186
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+#     -analytical_expression                1.8438E+0   0             4.4650737E+3   0   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: JAC2009
+    # Description: Stability range: LOT/MAT2008: C-S-H phases metastable w.r. to jennite, tobermorite or afwillite, but even at 85C, C-S-H has been found to be only partially crystallized (bulk solubility still dominated by gel present).
+
+# CSH(1.8)
+# Disabled. Please see Description for details.
+    # Description: Representative phase for high-Ca CSH.
+#     Ca1.8SiO3.8:3.6H2O + 3.6 H+ = 1.8 Ca+2 + 3.4 H2O + Si(OH)4
+    # Description: CEMDATA07, obsolete, deactivated
+    # Editor: Miron
+#     log_k     32.329446587288
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+#     -analytical_expression                 4.526E+0   0             8.2895976E+3   0   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: JAC2009
+    # Description: Stability range: LOT/MAT2008: C-S-H phases metastable w.r. to jennite, tobermorite or afwillite, but even at 85C, C-S-H has been found to be only partially crystallized (bulk solubility still dominated by gel present).
+
+# CdCl2:(Cd(OH)2)2_active(s)
+# Disabled. Please see Description for details.
+    # Description: metastable
+#     Cd3Cl2(OH)4 + 4 H+ = 3 Cd+2 + 2 Cl- + 4 H2O
+    # Original equation: 3Cd<2+>+2Cl<->+4OH<->=CdCl2:2Cd(OH)2_active
+    # Editor: Moog
+#     log_k     21.2
+    # Evaluation data class: 1, data quality: 3
+    # Reference: FEI/REI1951
+    # Description: Original LOGK298 for dissolution reaction = -34.8
+
+# CdCl2:(Cd(OH)2)2_inactive(s)
+# Disabled. Please see Description for details.
+    # Description: metastable
+#     Cd3Cl2(OH)4 + 4 H+ = 3 Cd+2 + 2 Cl- + 4 H2O
+    # Original equation: 3Cd<2+>+2Cl<->+4OH<->=CdCl2:2Cd(OH)2_inactive
+    # Editor: Moog
+#     log_k     20.0
+    # Evaluation data class: -1, data quality: 3
+    # Reference: FEI/REI1951
+    # Description: Original LOGK298 for dissolution reaction = -36
+
+# CdCl2:H2O(cr)
+# Disabled. Please see Description for details.
+#     CdCl2:H2O = Cd+2 + 2 Cl- + H2O
+    # Description: Stable at T > 34C, metastable at lower temperatures
+    # Original equation: CdCl2(cr) + H2O(g) = CdCl2:H2O
+    # Editor: Moog
+#     log_k     -1.736
+    # Evaluation data class: 1, data quality: 3
+    # Reference: HAG2024
+    # Description: Formed at 34C from CdCl25/2H2O. Metastable at lower temperatures. Average value for solubility from two sources is 7.47 mol/kg. The solubility constant is derived from that value.
+
+# CdSO4:(Cd(OH)2)3.5:H2O(cr)
+# Disabled. Please see Description for details.
+    # Description: metastable
+#     Cd4.5(OH)7(SO4):H2O = 4.5 Cd+2 + H2O + 7 OH- + SO4-2
+    # Editor: Moog
+#     log_k     43.4
+    # Evaluation data class: 1, data quality: 3
+    # Reference: HAG2024
+    # Additional reference: FEI1945
+    # Description: Original LOGK298 for dissolution reaction = -54.6
+
+# Cm(OH)3(cr)
+# Disabled because no reversible thermodynamic equilibrium is expected.
+#     Cm(OH)3 + 3 H+ = Cm+3 + 3 H2O
+    # Editor: Marquardt
+#     log_k     15.6
+    # Evaluation data class: 2, data quality: 1
+    # Reference: NEC/ALT2009
+    # Additional reference: RAB/ALT2008
+
+# Cm2(CO3)3_hyd(am)
+# Disabled because no reversible thermodynamic equilibrium is expected.
+#     Cm2(CO3)3 = 3 CO3-2 + 2 Cm+3
+    # Editor: Marquardt
+#     log_k     -33.4
+    # Evaluation data class: 2, data quality: 2
+    # Reference: GUI/FAN2003
+
+# Cs(TcO4)(cr)
+# Disabled. Please see Description for details.
+#     Cs(TcO4) = Cs+ + TcO4-
+    # Description: thermodynamic data not welll known!
+    # Editor: Kiefer
+#     log_k     -3.617
+    # Evaluation data class: 1, data quality: 1
+    # Reference: RAR/RAN1999
+
+# Ettringite
+# Disabled. Please see Description for details.
+    # Synonyms: Woodfordite
+#     Ca6Al2(SO4)3(OH)12:26H2O + 4 H+ = 2 Al(OH)4- + 6 Ca+2 + 30 H2O + 3 SO4-2
+    # Description: CEMDATA07, obsolete, deactivated. Original reaction from CEMDATA07, LOGK298 = -44.9
+    # Original equation: Ca6Al2(SO4)3(OH)12:26H2O = 6 Ca<2+> + 2 Al(OH)4<-> + 3 SO4<2-> + 4 OH<-> + 26 H2O(l)
+    # Editor: Miron
+#     log_k     11.157847443935
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+#     -analytical_expression              2.498866E+2   0            -9.5794928E+3     -8.34934002409863E+1   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: JAC2009
+    # Description: Stability range: LOT/MAT2008: Sol. from  5 to 85C, ettringite starts conversion to monosulph. at 48C in Portland cem., stable in equil. with water up to 75C or higher. BAL2010: Stable in water up to at least 110C, up to 70C in cement pastes.
+
+# K(TcO4)(cr)
+# Disabled. Please see Description for details.
+#     K(TcO4) = K+ + TcO4-
+    # Description: thermodynamic data not welll known!
+    # Editor: Kiefer
+#     log_k     -2.288
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+# K2(TcCl6)(cr)
+# Disabled. Please see Description for details.
+#     K2(TcCl6) + 3 H2O = 6 Cl- + 4 H+ + 2 K+ + TcO(OH)2
+    # Description: thermodynamic data not well known!
+    # Editor: Kiefer
+#     log_k     -10.924
+    # Evaluation data class: 1, data quality: 1
+    # Reference: RAR/RAN1999
+    # Additional reference: HES/XIA2004
+
+# Na(TcO4):4H2O(s)
+# Disabled. Please see Description for details.
+#     Na(TcO4):4H2O = 4 H2O + Na+ + TcO4-
+    # Description: thermodynamic data not well known!
+    # Editor: Kiefer
+#     log_k     0.79
+    # Evaluation data class: 1, data quality: 1
+    # Reference: RAR/RAN1999
+
+# Na2U2O7(cr)
+# Disabled because no reversible thermodynamic equilibrium is expected.
+#     Na2U2O7 + 6 H+ = 3 H2O + 2 Na+ + 2 UO2+2
+    # Description: formation data from thermochemical experiments in  [GUI/FAN2003], not selected for THEREDA, therefore data for Na[(UO2)O(OH)](cr) from solubility experiments in [ALT/BRE2004]
+    # Editor: Richter
+#     log_k     0.0
+
+# Nd(OH)3(cr)
+# Disabled because no reversible thermodynamic equilibrium is expected.
+#     Nd(OH)3 + 3 H+ = 3 H2O + Nd+3
+    # Editor: Marquardt
+#     log_k     16.0
+    # Evaluation data class: 1, data quality: 1
+    # Reference: NEC/ALT2009
+    # Additional reference: DIA/TAG1998
+
+# Np2O5(cr)
+# Disabled because no reversible thermodynamic equilibrium is expected.
+#     Np2O5 + 2 H+ = H2O + 2 NpO2+
+    # Original equation: NpO2<+> + OH<-> = NpO2.5 + 0.5 H2O
+    # Editor: Marquardt
+#     log_k     3.3
+    # Evaluation data class: 1, data quality: 3
+    # Reference: ALT/BRE2004
+    # Additional reference: PAN/CAM1998
+    # Description: The value of LOGK298 is a mean value of solubility experiments by PAN/CAM1998 and EFU/RUN1998.  Original reaction: NpO2<+> + OH<-> = NpO2.5 + 0.5 H2O; LOGK298 = 10.7 +- 1.0
+
+# NpO2(OH)_aged(s)
+# Disabled because no reversible thermodynamic equilibrium is expected.
+    # Description: The aged (white) solid may be a slightly more ripened form of the hydroxide, or it may be a material with a surface layer of Np2O5, or even incorporating alkali metal ions.
+#     NpO2(OH) + H+ = H2O + NpO2+
+    # Editor: Marquardt
+#     log_k     4.7
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GUI/FAN2003
+
+# Schoepite
+# Disabled because no reversible thermodynamic equilibrium is expected.
+    # Synonyms: Epiianthinite
+#     UO3:2H2O + 2 H+ = 3 H2O + UO2+2
+    # Description: "Schoepite" commonly applied to a mineral with a formula close to UO3:2H2O (correct: metaschoepite). logK calculated from thermochemical data [GUI/FAN2003], not suitable for solubility predictions!
+    # Editor: Richter
+#     log_k     0.0
+
+# SeO2(cr)
+# Disabled because no reversible thermodynamic equilibrium is expected.
+    # Synonyms: Downeyite, Selenium(IV) oxide
+#     SeO2 + H2O = 2 H+ + SeO3-2
+    # Description: Data added to calculate the dissolution of oxidic SeO2(cr) only. Phase will not form from aqueous solution.
+    # Editor: Bok
+#     log_k     -8.1542644566871
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CF
+#     -analytical_expression     -7.44298728353251E+0   0     -2.12067289176055E+2   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+
+# SeO3(cr)
+# Disabled because no reversible thermodynamic equilibrium is expected.
+    # Synonyms: Selenium(VI) oxide
+#     SeO3 + H2O = 2 H+ + SeO4-2
+    # Description: Data added to calculate the dissolution of oxidic SeO3(cr) only. Phase will not form from aqueous solution.
+    # Editor: Bok
+#     log_k     20.355603658947
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CF
+#     -analytical_expression     -6.72373443329746E+0   0      8.07370465220267E+3   0   0   0 
+    # Evaluation data class: -1, data quality: -1
+    # Temperature range min - max: 298.15 K - 298.15 K. The temperature function given should be regarded as estimate only with unknown range of validity in terms of temperature.
+    # Reference: internally calculated with calcmode = CXTERMEXTRAP
+
+# Si-Hydrogarnet
+# Disabled. Please see Description for details.
+    # Synonyms: Si-Hydrogranat
+#     Ca3Al2(SiO4)0.8(OH)8.8 + 4 H+ = 2 Al(OH)4- + 3 Ca+2 + 0.8 H2O + 0.8 Si(OH)4
+    # Description: CEMDATA07, obsolete, deactivated. Original reaction from CEMDATA07, LOGK298 = -29.87
+    # Original equation: Ca3Al2(SiO4)0.8(OH)8.8(cr) + 2.4 H2O(l) = 3 Ca<2+> + 2 Al(OH)4<-> + 0.8 SiO(OH)3<-> + 3.2 OH<->
+    # Editor: Miron
+#     log_k     22.782833695951
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+#     -analytical_expression               2.75598E+1   0             7.1311125E+3     -1.15965208167714E+1   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: JAC2009
+    # Description: Stability range: MAT/LOT2007: Solubilities from 5 to 85C.
+
+# SiO2(am)
+# Disabled. Please see Description for details.
+    # Synonyms: SiO2(am)
+#     SiO2 + 2 H2O = Si(OH)4
+    # Description: Water free amorphous silica following e.g. [GUN/ARN2000]. Not considered as the hydrous form SiO2:xH2O(am) (with x = 2 in THEREDA) is more likely to govern reactions in aqueous solutions.
+    # Editor: Miron
+#     log_k     -2.7135472113489
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+#     -analytical_expression                -8.476E+0   0               -4.8524E+2      3.06799999889666E+0   0                -2.268E-6 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: GUN/ARN2000
+
+# Stratlingite
+# Disabled. Please see Description for details.
+    # Synonyms: Gehlenite hydrate, Straetlingite, Strätlingite
+#     Ca2Al2SiO2(OH)10:3H2O + 2 H+ = 2 Al(OH)4- + 2 Ca+2 + 3 H2O + Si(OH)4
+    # Description: CEMDATA07, obsolete, deactivated. Original reaction from CEMDATA07, LOGK298 = -19.70
+    # Original equation: Ca2Al2SiO2(OH)10:3H2O(cr) = 2 Ca<2+> + 2 Al(OH)4<-> + SiO(OH)3<-> + OH<-> + 2 H2O(l)
+    # Editor: Miron
+#     log_k     4.1142093899675
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+#     -analytical_expression               1.14028E+1   0             1.3671609E+3     -4.79870016046915E+0   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: JAC2009
+    # Description: Stability range: MAT/LOT2007: Experimental data from 5 to 85C.
+
+# TcCl4(am)
+# Disabled. Please see Description for details.
+#     TcCl4 + 3 H2O = 4 Cl- + 4 H+ + TcO(OH)2
+    # Description: thermodynamic data not welll known!
+    # Editor: Kiefer
+#     log_k     -9.266
+    # Evaluation data class: 1, data quality: 1
+    # Reference: HES/XIA2004
+
+# TcO2:1.6H2O(s)
+# Disabled. Please see Description for details.
+#     TcO2:1.6H2O = 0.6 H2O + TcO(OH)2
+    # Description: Chemical model updated! Replaced with TcO2:0.6H2O(s). Corresponding equivalent in NEA-TDB: TcO2(am, hyd, fresh)
+    # Editor: Kiefer
+#     log_k     -7.66
+    # Evaluation data class: 1, data quality: 1
+    # Reference: GRE/GAO2020
+
+# Th(OH)4_fresh(am)
+# Disabled because no reversible thermodynamic equilibrium is expected.
+#     Th(OH)4 + 4 H+ = 4 H2O + Th+4
+    # Original equation: 4OH<-> + Th<4+> --> 2H2O(l) + ThO2(am,hyd,fresh) ; logK>=46.7 (RAN/FUG2008)
+    # Editor: Marquardt
+#     log_k     9.3
+    # Evaluation data class: 1, data quality: 2
+    # Reference: RAN/FUG2008
+    # Description: 4OH<-> + Th<4+> --> 2H2O(l) + ThO2(am,hyd,fresh) ; logK=46.7 (RAN/FUG2008)
+
+# Tricarboaluminate
+# Disabled. Please see Description for details.
+    # Synonyms: Tricarbonat
+#     Ca6Al2(CO3)3(OH)12:26H2O + 4 H+ = 2 Al(OH)4- + 3 CO3-2 + 6 Ca+2 + 30 H2O
+    # Description: CEMDATA07, obsolete, deactivated. Original reaction from CEMDATA07, LOGK298 =-46.5
+    # Original equation: Ca6Al2(CO3)3(OH)12:26H2O(cr) = 6 Ca<2+> + 2 Al(OH)4<-> + 3 CO3<2-> + 4 OH<-> + 26 H2O(l)
+    # Editor: Miron
+#     log_k     9.5214132296133
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CTPFUNC
+#     -analytical_expression              2.468926E+2   0            -7.7550037E+3     -8.54177995479667E+1   0   0 
+    # Evaluation data class: 1, data quality: 1
+    # Temperature range min - max: 273.15 K - 373.15 K.
+    # Reference: JAC2009
+    # Description: Stability range: LOT/MAT2008: Only data available for 25C, estimated rS = rCp = 0.
+
+# Uraninite
+# Disabled because no reversible thermodynamic equilibrium is expected.
+    # Synonyms: Uranatemnite, Uranopissite
+#     UO2 + 4 H+ = 2 H2O + U+4
+    # Description: logK calculated from thermochemical data [GUI/FAN2003], not suitable for solubility predictions in geochemical modelling!
+    # Editor: Richter
+#     log_k     -4.8516283647781
+    # Evaluation data class: -1, data quality: -1
+    # Reference: internally calculated with calcmode = CF
+    # Description: logK calculated from thermochemical data [GUI/FAN2003], not suitable for solubility predictions!, solubilty is too low compared to experimental solubility measurements!
+
+# #### References ##############################################################
+
+# AGR/BUS1985
+#    Type: Article
+#    Language: English
+#    Title: Magnesium dichloride hexahydrate, MgCl2·6H2O, by neutron diffraction
+#    Author: Agron, P. A., Busing, W. R.
+#    Pubname: Acta Crystallographica, Section C: Crystal Structure Communications
+#    Year: 1985
+#    Volume: 41(1)
+#    Page: 8-10
+#    Doi: 10.1107/s0108270185002591
+
+# AGR/BUS1986
+#    Type: Article
+#    Language: English
+#    Title: Calcium and strontium dichloride hexahydrates by neutron diffraction
+#    Author: Agron, P. A., Busing, W. R.
+#    Pubname: Acta Crystallographica, Section C: Crystal Structure Communications
+#    Year: 1986
+#    Volume: 42(2)
+#    Page: 141-143
+#    Doi: 10.1107/s0108270186097007
+
+# AKA/IWA1977
+#    Type: Article
+#    Language: English
+#    Title: The hydrogen bonding of artinite
+#    Author: Akao, M., Iwai, S.
+#    Pubname: Acta Crystallographica B
+#    Year: 1977
+#    Volume: 33(12)
+#    Page: 3951-3953
+#    Publisher: International Union of Crystallography ({IUCr})
+#    Doi: 10.1107/s0567740877012576
+
+# AKA/IWA1977a
+#    Type: Article
+#    Language: English
+#    Title: The hydrogen bonding of hydromagnesite
+#    Author: Akao, M., Iwai, S.
+#    Pubname: Acta Crystallographica B
+#    Year: 1977
+#    Volume: 33(4)
+#    Page: 1273-1275
+#    Publisher: International Union of Crystallography ({IUCr})
+#    Doi: 10.1107/s0567740877005834
+
+# ALT/BRE2004
+#    Type: Report
+#    Language: German
+#    Title: Sichtung. Zusammenstellung und Bewertung von Daten zur geochemischen Modellierung
+#    Author: Altmaier, M., Bosbach, D., Brendler, V., Kienzler, B., Marquardt, C., Neck, V., Richter, A.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2004
+#    Publisher: Institut für Nukleare Entsorgung
+
+# ALT/BRE2011
+#    Type: Report
+#    Language: German
+#    Title: THEREDA - Thermodynamische Referenzdatenbasis
+#    Author: Altmaier, M., Brendler, V., Bube, C., Marquardt, C., Moog, H. C., Richter, A., Scharge, T., Voigt, W., Wilhelm, S., Wilms, T., Wollmann, G.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2011
+#    Publisher: GRS
+#    Puburl: https://www.grs.de/content/grs-265-thereda-thermodynamische-referenzdatenbasis-abschlussbericht
+#    Location: Köln
+
+# ALT/NEC2005a
+#    Type: Contribution to Proceeding
+#    Language: English
+#    Title: Solubility of U(VI) and formation of CaU2O7:3H2O(cr) in alkaline CaCl2 solutions
+#    Author: Altmaier, M., Fanghänel, T., Müller, R., Neck, V.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2005
+#    Page: 143
+#    Location: Avignon (FR)
+
+# ALT/YAL2017
+#    Type: Article
+#    Language: English
+#    Title: Solubility of U(VI) in chloride solutions. I. The stable oxides/hydroxides in NaCl systems, solubility products, hydrolysis constants and SIT coefficients
+#    Author: Altmaier, M., Fanghänel, T., Gaona, X., Müller, R., Neck, V., Schlieker, M., Yalcintas, E.
+#    Pubname: Journal of Chemical Thermodynamics
+#    Year: 2017
+#    Volume: 114
+#    Page: 2-13
+#    Doi: 10.1016/j.jct.2017.05.039
+
+# ALW/WIL1980
+#    Type: Article
+#    Language: English
+#    Title: The aqueous chemistry of uranium minerals. Part 2. Minerals of the liebigite group
+#    Author: Alwan, A. K., Williams, P. A.
+#    Pubname: Mineralogical Magazine
+#    Year: 1980
+#    Volume: 43(329)
+#    Page: 665-667
+#    Doi: 10.1180/minmag.1980.043.329.17
+
+# ANT/HAS2010
+#    Type: Article
+#    Language: English
+#    Title: Temperature dependence of the structural parameters in the transformation of aragonite to calcite, as determined from in situ synchrotron powder X-ray diffraction data
+#    Author: Antao, S. M., Hassan, I.
+#    Pubname: Canadian Mineralogist
+#    Year: 2010
+#    Volume: 48(5)
+#    Page: 1225-1236
+#    Doi: 10.3749/canmin.48.5.1225
+
+# BAL/GLA2009
+#    Type: Article
+#    Language: English
+#    Title: The density of cement phases
+#    Author: Balonis, M., Glasser, F. P.
+#    Pubname: Cement and Concrete Research
+#    Year: 2009
+#    Volume: 39
+#    Page: 733-739
+#    Doi: 10.1016/j.cemconres.2009.06.005
+
+# BAL/LOT2010
+#    Type: Article
+#    Language: English
+#    Title: Impact of chloride on the mineralogy of hydrated Portland cement systems
+#    Author: Balonis, M., Glasser, F. P., LeSaout, G., Lothenbach, B.
+#    Pubname: Cement and Concrete Research
+#    Year: 2010
+#    Volume: 40
+#    Page: 1009-1022
+#    Doi: 10.1016/j.cemconres.2010.03.002
+
+# BAL/PAM2020
+#    Type: Article
+#    Language: English
+#    Title: Redetermination and new description of the crystal structure of vanthoffite, Na6Mg(SO4)4
+#    Author: Balic-Zunic, T., Nestola, F., Pamato, M.
+#    Pubname: Acta Crystallographica Section E Crystallographic Communications
+#    Year: 2020
+#    Volume: 76(6)
+#    Page: 785-789
+#    Publisher: International Union of Crystallography ({IUCr})
+#    Doi: 10.1107/s2056989020005873
+
+# BAQ/MAT2014
+#    Type: Article
+#    Language: English
+#    Title: Methods to determine hydration states of minerals and cement hydrates
+#    Author: Baquerizo, L. G., Matschei, T., Saeidpour, M., Scrivener, K. L., Thorell, A., Wadsö, L.
+#    Pubname: Cement and Concrete Research
+#    Year: 2014
+#    Volume: 65
+#    Page: 85-95
+#    Doi: 10.1016/j.cemconres.2014.07.009
+
+# BAQ/MAT2015
+#    Type: Article
+#    Language: English
+#    Title: Hydration states of AFm cement phases
+#    Author: Baquerizo, L. G., Matschei, T., Saeidpour, M., Scrivener, K. L., Wadsö, L.
+#    Pubname: Cement and Concrete Research
+#    Year: 2015
+#    Volume: 73
+#    Page: 143-157
+#    Doi: 10.1016/j.cemconres.2015.02.011
+
+# BAQ/MAT2016
+#    Type: Article
+#    Language: English
+#    Title: Impact of water activity on the stability of ettringite
+#    Author: Baquerizo, L. G., Matschei, T., Scrivener, K. L.
+#    Pubname: Cement and Concrete Research
+#    Year: 2016
+#    Volume: 79
+#    Page: 31-44
+#    Doi: 10.1016/j.cemconres.2015.07.008
+
+# BAR/WAL1954
+#    Type: Article
+#    Language: English
+#    Title: Studies of NaCl-KCl Solid Solutions. I. Heats of Formation, Lattice Spacings, Densities, Schottky Defects and Mutual Solubilities
+#    Author: Barrett, W. T., Wallace, W. E.
+#    Pubname: Journal of the American Chemical Society
+#    Year: 1954
+#    Volume: 76(2)
+#    Page: 366-369
+#    Doi: 10.1021/ja01631a014
+
+# BEN/PAL2001
+#    Type: Article
+#    Language: English
+#    Title: Aqueous high-temperature solubility studies. II. The solubility of boehmite at 0.03 m ionic strength as a function of temperature and pH as determined by in situ measurements
+#    Author: Benezeth, P., Palmer, D. A., Wesolowski, D. J.
+#    Pubname: Geochimica et Cosmochimica Acta
+#    Year: 2001
+#    Volume: 65
+#    Page: 2097-2111
+#    Doi: 10.1016/S0016-7037(01)00585-3
+#    Puburl: http://www.sciencedirect.com/science/article/pii/S0016703701005853
+
+# BIN2005
+#    Type: Article
+#    Language: English
+#    Title: Reinvestigation of polyhalite, K2Ca2Mg(SO4)4·2H2O
+#    Author: Bindi, L.
+#    Pubname: Acta Crystallographica Section E Crystallographic Communications
+#    Year: 2005
+#    Volume: 61(8)
+#    Page: 135-136
+#    Publisher: International Union of Crystallography ({IUCr})
+#    Doi: 10.1107/s1600536805020507
+
+# BIS/GOG2012
+#    Type: Article
+#    Language: English
+#    Title: The heat capacity and thermodynamic functions of cerussite
+#    Author: Bekturganov, N. S., Bissengaliyeva, M. R., Gogol, D. B., Taimassova, S. T.
+#    Pubname: Journal of Chemical Thermodynamics
+#    Year: 2012
+#    Volume: 47
+#    Page: 197-202
+#    Doi: 10.1016/j.jct.2011.10.014
+
+# BIS/HAG2016
+#    Type: Report
+#    Language: English
+#    Title: VESPA - Behaviour of Long-Lived Fission and Activation Products in the Nearfield of a Nuclear Waste Repository and the Possibilities of their Retention
+#    Author: Altmaier, M., Banik, N., Bischofer, B., Bosbach, D., Bracke, G., Brendler, V., Curtius, H., Finck, N., Franzen, C., Gaona, X., Geckeis, H., Hagemann, S., Heberling, F., Herm, M., Kindlein, J., Marsac, R., Metz, V., Munoz, A. G., Rozov, K., Scharge, T., Schäfer, T., Totskiy, Y., Wiedemann, M., Yalcintas, E.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2016
+#    Page: 757
+#    Publisher: GRS
+
+# BOK/MOO2023
+#    Type: Article
+#    Language: English
+#    Title: The solubility of oxygen in water and saline solutions
+#    Author: Bok, F., Brendler, V., Moog, H. C.
+#    Pubname: Frontiers in Nuclear Engineering
+#    Year: 2023
+#    Volume: 2
+#    Page: 1158109
+#    Doi: 10.3389/fnuen.2023.1158109
+
+# BOK2021
+#    Type: THEREDA-Report
+#    Language: English
+#    Title: Thermodynamic model for the systems Se(+VI,+IV) – Na, K, Mg, Ca – Cl, SO4, CO3 – H2O at T = 0–100 °C
+#    Author: Bok, F.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2021
+#    Page: 48
+
+# BOK2023
+#    Type: THEREDA-Journal
+#    Language: English
+#    Title: Formation constant of the double salt CsCl·2NaCl·2H2O(cr)
+#    Author: Bok, F.
+#    Pubname: THEREDA Journal
+#    Year: 2023
+#    Volume: 3(1)
+#    Page: 1-6
+#    Location: Freiberg
+
+# BOS/BEL2009
+#    Type: Article
+#    Language: English
+#    Title: Structural features in Tutton's salts K2[M2+(H2O)6](SO4)2, with M2+ = Mg, Fe, Co, Ni, Cu, and Zn
+#    Author: Ballirano, P., Belardi, G., Bosi, F.
+#    Pubname: American Mineralogist
+#    Year: 2009
+#    Volume: 94(1)
+#    Page: 74-82
+#    Publisher: Mineralogical Society of America
+#    Doi: 10.2138/am.2009.2898
+
+# BRO/EKB2016
+#    Type: Book
+#    Language: English
+#    Title: Hydrolysis of Metal Ions
+#    Author: Brown, P. L., Ekberg, C.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2016
+
+# BUS/PLU1984
+#    Type: Article
+#    Language: English
+#    Title: The solubility of strontianite (SrCO3) in CO2-H2O solutions between 2 and 91°C
+#    Author: Busenberg, E., Parker, V. B., Plummer, L. N.
+#    Pubname: Geochimica et Cosmochimica Acta
+#    Year: 1984
+#    Volume: 48
+#    Page: 2021-2035
+#    Doi: 10.1016/0016-7037(84)90383-1
+
+# CEV/YAL2018
+#    Type: Article
+#    Language: English
+#    Title: Solubility of U(VI) in chloride solutions. II. The stable oxides/hydroxides in alkaline KCl solutions: Thermodynamic description and relevance in cementitious systems
+#    Author: Altmaier, M., Cevirim-Papaioannou, N., Gaona, X., Geckeis, H., Yalcintas, E.
+#    Pubname: Applied Geochemistry
+#    Year: 2018
+#    Volume: 98
+#    Page: 237-246
+#    Doi: 10.1016/j.apgeochem.2018.09.017
+
+# CEV2018
+#    Type: Ph.D. thesis
+#    Language: English
+#    Title: Redox chemistry, solubility and hydrolysis of uranium in dilute to concentrated salt systems
+#    Author: Cevirim-Papaioannou, N.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2018
+#    Page: 152
+#    Publisher: Karlsruher Institut für Technologie (Germany). Fakultät fuer Chemie und Biowissenschaften
+#    Puburl: https://publikationen.bibliothek.kit.edu/1000084978/18481302
+#    Location: Karlsruhe
+
+# CHA/CRU2021
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamic Modeling of Mutual Solubilities in Gas-Laden Brines Systems Containing CO2, CH4, N2, O2, H2, H2O, NaCl, CaCl2, and KCl - Application to Degassing in Geothermal Processes
+#    Author: Chabab, S., Contamine, F., Cruz, J. L., Cézac, P., Ducousso, M., Poulain, M., Serin, J. P.
+#    Pubname: Energies
+#    Year: 2021
+#    Volume: 14
+#    Page: 5239
+#    Doi: 10.3390/en14175239
+
+# CHA1998
+#    Type: Book
+#    Language: English
+#    Title: NIST-JANAF Thermochemical Tables. Journal of Physical and Reference Data, Monograph No. 9
+#    Author: Chase, M. W.
+#    Pubname: not applicable because source is not a journal
+#    Year: 1998
+#    Publisher: National Institute of Standards and Technology
+#    Edition: 4th
+
+# CLA/EVA1980
+#    Type: Article
+#    Language: English
+#    Title: Tachyhydrite, dimagnesium calcium chloride 12-hydrate
+#    Author: Clark, J. R., Erd, R. C., Evans, H. T.
+#    Pubname: Acta Crystallographica B
+#    Year: 1980
+#    Volume: 36(11)
+#    Page: 2736-2739
+#    Publisher: International Union of Crystallography ({IUCr})
+#    Doi: 10.1107/s0567740880009818
+
+# COR/SAB1967
+#    Type: Article
+#    Language: English
+#    Title: The crystal structure of syngenite, K2Ca(SO4)2·H2O
+#    Author: Corazza, E., Sabelli, C.
+#    Pubname: Zeitschrift für Kristallographie
+#    Year: 1967
+#    Volume: 124(6)
+#    Page: 398-408
+#    Doi: 10.1524/zkri.1967.124.6.398
+
+# COX/WAG1989
+#    Type: Book
+#    Language: English
+#    Title: CODATA Key Values for Thermodynamics
+#    Author: Cox, J. D., Medvedev, V. A., Wagman, D. D.
+#    Pubname: not applicable because source is not a journal
+#    Year: 1989
+#    Page: 1 - 271
+#    Publisher: Hemisphere Publ. Corp.
+#    Location: New York
+
+# DES/CAL1996
+#    Type: Article
+#    Language: English
+#    Title: Interlayer interactions in M(OH)2: a neutron diffraction study of Mg(OH)2
+#    Author: Calvarin, G., Chevrier, G., Desgranges, L.
+#    Pubname: Acta Crystallographica, Section B: Structural Science
+#    Year: 1996
+#    Volume: 52(1)
+#    Page: 82-86
+#    Publisher: International Union of Crystallography ({IUCr})
+#    Doi: 10.1107/s0108768195008275
+
+# DES/GRE1993
+#    Type: Article
+#    Language: English
+#    Title: Hydrogen thermal motion in calcium hydroxide: Ca(OH)2
+#    Author: Calvarin, G., Chevrier, G., Desgranges, L., Floquet, N., Grebille, D., Niepce, J. C.
+#    Pubname: Acta Crystallographica, Section B: Structural Science
+#    Year: 1993
+#    Volume: 49(5)
+#    Page: 812-817
+#    Publisher: International Union of Crystallography ({IUCr})
+#    Doi: 10.1107/s0108768193003556
+
+# DEW/WAL1953
+#    Type: Article
+#    Language: English
+#    Title: The crystal structure of Mg2(OH)3(Cl,Br)·4H2O
+#    Author: Walter-Lévy, L., de Wolff, P. M.
+#    Pubname: Acta Crystallographica
+#    Year: 1953
+#    Volume: 6(1)
+#    Page: 40-44
+#    Doi: 10.1107/s0365110x53000089
+
+# DIA/TAG1998
+#    Type: Article
+#    Language: English
+#    Title: Standard thermodynamic properties and heat capacity equations for rare earth element hydroxides. I. La(OH)3(s) and Nd(OH)3(s). Comparison of thermochemical and solubility data
+#    Author: Diakonov, I. I., Ragnarsdottir, K. V., Tagirov, B. R.
+#    Pubname: Radiochimica Acta
+#    Year: 1998
+#    Volume: 81(2)
+#    Page: 107-116
+#    Publisher: Oldenbourg Wissenschaftsverlag
+#    Location: München
+
+# DIL/LOT2014
+#    Type: Article
+#    Language: English
+#    Title: Synthesis and characterization of hydrogarnet Ca3(AlxFe1−x)2(SiO4)y(OH)4(3−y)
+#    Author: Dilnesa, B. Z., Kulik, D. A., Lothenbach, B., Renaudin, G., Wichser, A.
+#    Pubname: Cement and Concrete Research
+#    Year: 2014
+#    Volume: 59
+#    Page: 96-111
+#    Doi: 10.1016/j.cemconres.2014.02.001
+
+# DIN/FRE2010
+#    Type: Article
+#    Language: English
+#    Title: 9Mg(OH)2·MgCl2·4H2O, a High Temperature Phase of the Magnesia Binder System
+#    Author: Bette, S., Dinnebier, R. E., Freyer, D., Oestreich, M.
+#    Pubname: Inorganic Chemistry
+#    Year: 2010
+#    Volume: 49(21)
+#    Page: 9770-9776
+#    Doi: 10.1021/ic1004566
+
+# DIN/OES2012
+#    Type: Article
+#    Language: English
+#    Title: 2Mg(OH)2·MgCl2·2H2O and 2Mg(OH)2·MgCl2·4H2O, Two High Temperature Phases of the Magnesia Cement System
+#    Author: Bette, S., Dinnebier, R. E., Freyer, D., Oestreich, M.
+#    Pubname: Zeitschrift für Anorganische und Allgemeine Chemie
+#    Year: 2012
+#    Volume: 638(3-4)
+#    Page: 628-633
+#    Doi: 10.1002/zaac.201100497
+
+# DOS/HAU2026
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamic description of the Eu(III)-Na-NO3-H2O and Eu(III)-Mg-NO3-H2O systems. Part II: spectroscopy experiments and partial dissociation SIT & Pitzer models
+#    Author: Altmaier, M., Gaona, X., Häusler, F., Lassin, A., Madé, B., Skerencak, A., dos Santos, P. F.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2026
+
+# DYR/IVA1969
+#    Type: Article
+#    Language: English
+#    Title: Solubility curves of calcium , strontium, and lead sulfates
+#    Author: Dyrssen, D., Ivanova, E. K., Oren, K.
+#    Pubname: Vestnik Moskovskogo Universiteta : naučnyj žurnal. Serija 2, Chimija
+#    Year: 1969
+#    Volume: 24
+#    Page: 32-35
+
+# EFF/MER1981
+#    Type: Article
+#    Language: English
+#    Title: Crystal structure refinements of magnesite, calcite, rhodochrosite, siderite, smithonite, and dolomite, with discussion of some aspects of the stereochemistry of calcite type carbonates
+#    Author: Effenberger, H., Mereiter, K., Zemann, J.
+#    Pubname: Zeitschrift für Kristallographie - Crystalline Materials
+#    Year: 1981
+#    Volume: 156(3-4)
+#    Page: 233-243
+#    Publisher: Walter de Gruyter {GmbH}
+#    Doi: 10.1524/zkri.1981.156.3-4.233
+
+# FAN/KON1999
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamics of Cm(III) in concentrated salt solutions: Carbonate complexation in NaCl solution at 25 degrees C
+#    Author: Fanghänel, T., Kim, J. I., Könnecke, T., Neck, V., Paviet-Hartmann, P., Weger, H.
+#    Pubname: Journal of Solution Chemistry
+#    Year: 1999
+#    Volume: 28(4)
+#    Page: 447-462
+#    Publisher: Springer
+#    Doi: 10.1023/A:1022664013648
+#    Puburl: http://www.springerlink.com/content/l53x021103777494/
+
+# FAN/NEC1995
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamics of Neptunium(V) in Concentrated Salt Solutions. II. Ion Interaction (Pitzer) Parameters for Np(V) Hydrolysis Species and Carbonate Complexes
+#    Author: Fanghänel, T., Kim, J. I., Neck, V.
+#    Pubname: Radiochimica Acta
+#    Year: 1995
+#    Volume: 69(3)
+#    Page: 169-176
+#    Publisher: Oldenbourg Verlag
+#    Location: München
+
+# FAN/ROB1970
+#    Type: Article
+#    Language: English
+#    Title: Crystal structures and mineral chemistry of double-salt hydrates: II. The crystal structure of Loeweite
+#    Author: Fang, J. H., Robinson, P. D.
+#    Pubname: American Mineralogist
+#    Year: 1970
+#    Volume: 55
+#    Page: 378-386
+
+# FEI/REI1951
+#    Type: Article
+#    Language: German
+#    Title: Die Löslichkeitsprodukte der Cadmiumhydroxychloride und des Cadmiumhydroxids
+#    Author: Feitknecht, W., Reinmann, R.
+#    Pubname: not applicable because source is not a journal
+#    Year: 1951
+#    Volume: 34(7)
+#    Page: 2255-2266
+#    Doi: 10.1002/hlca.19510340722
+
+# FEI1945
+#    Type: Article
+#    Language: German
+#    Title: Über die Fällung von Hydroxysalzen aus Cadmiumlösungen
+#    Author: Feitknecht, W.
+#    Pubname: not applicable because source is not a journal
+#    Year: 1945
+#    Volume: 28(1)
+#    Page: 1444-1454
+#    Doi: 10.1002/hlca.6602801205
+
+# FEL/ALT2016
+#    Type: Article
+#    Language: English
+#    Title: Np(V) solubility, speciation and solid phase formation in alkaline CaCl2 solutions. Part II: Thermodynamics and implications for source term estimations of nuclear waste disposal
+#    Author: Altmaier, M., Fanghänel, T., Fellhauer, D., Gaona, X., Lützenkirchen, J.
+#    Pubname: Radiochimica Acta
+#    Year: 2016
+#    Volume: 104
+#    Page: 381-397
+#    Doi: 10.1515/ract-2015-2490
+
+# FEL/NEC2010
+#    Type: Article
+#    Language: English
+#    Title: Solubility of tetravalent actinides in alkaline CaCl2 solutions and formation of Ca4[An(OH)8]4+ complexes: A study of Np(IV) and Pu(IV) under reducing conditions and the systematic trend in the An(IV) series
+#    Author: Altmaier, M., Fanghänel, T., Fellhauer, D., Lützenkirchen, J., Neck, V.
+#    Pubname: Radiochimica Acta
+#    Year: 2010
+#    Volume: 98
+#    Page: 541
+#    Doi: 10.1524/ract.2010.1751
+#    Puburl: http://www.degruyter.com/view/j/ract.2010.98.issue-9-11/ract.2010.1751/ract.2010.1751.xml
+
+# FEL/RAI1997
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamic Models for Highly Charged Aqueous Species: Solubility of Th(IV) Hydrous Oxide in Concentrated NaHCO3 and Na2CO3 Solutions
+#    Author: Conradson, S. D., Felmy, A. R., Hess, N. J., Mason, M. J., Rai, D., Sterner, S. M.
+#    Pubname: Journal of Solution Chemistry
+#    Year: 1997
+#    Volume: 26(3)
+#    Page: 233-248
+#    Publisher: Springer
+#    Doi: 10.1007/BF02767996
+#    Puburl: http://www.springerlink.com/content/m1jn30q13t25h878/
+
+# FEL/RAI1999
+#    Type: Article
+#    Language: English
+#    Title: Application of Pitzers Equations for Modeling the Aqueous Thermodynamics of Actinide Species in Natural Waters: A Review
+#    Author: Felmy, A. R., Rai, D.
+#    Pubname: Journal of Solution Chemistry
+#    Year: 1999
+#    Volume: 28
+#    Page: 533-553
+#    Doi: 10.1023/A:1022630931742
+#    Puburl: https://link.springer.com/article/10.1023%2FA%3A1022630931742
+
+# FER/JON1973
+#    Type: Article
+#    Language: English
+#    Title: Refinement of the crystal structure of magnesium sulphate heptahydrate (epsomite) by neutron diffraction
+#    Author: Ferraris, G., Jones, D. W., Yerkess, J.
+#    Pubname: Journal of the Chemical Society, Dalton Transactions
+#    Year: 1973
+#    Volume: 8
+#    Page: 816-821
+#    Publisher: Royal Society of Chemistry ({RSC})
+#    Doi: 10.1039/dt9730000816
+
+# FRE/PAN2023
+#    Type: Article
+#    Language: English
+#    Title: Solid-liquid equilibria of Sorel phases and Mg(OH)2 in the system Na-Mg-Cl-OH-H2O. Part II: Pitzer modeling
+#    Author: Freyer, D., Pannach, M., Voigt, W.
+#    Pubname: Frontiers in Nuclear Engineering
+#    Year: 2023
+#    Volume: 2
+#    Page: 1236544
+#    Doi: 10.3389/fnuen.2023.1236544
+
+# FUG/OET1976
+#    Type: Book
+#    Language: English
+#    Title: The Chemical Thermodynamics of Actinide Elements and Compounds Part 2: The Actinide Aqueous Ions
+#    Author: Fuger, J., Oetting, F. L.
+#    Pubname: not applicable because source is not a journal
+#    Year: 1976
+#    Publisher: IAEA, International Atomic Energy Agency
+#    Location: Vienna
+
+# FUG/SPI1972
+#    Type: Article
+#    Language: English
+#    Title: A New Determination of the Heat of Solution of Americium Metal and the Heat of Formation of Various Americium Ions and Compounds
+#    Author: Fuger, J., Muller, W., Spirlet, J. C.
+#    Pubname: Inorganic Nuclear Chemistry Letters
+#    Year: 1972
+#    Volume: 8
+#    Page: 709-723
+#    Publisher: Pergamon Press.
+
+# GAY/HAA1960
+#    Type: Article
+#    Language: English
+#    Title: Hydrolysis of Cadmium Chloride at 25C
+#    Author: Gayer, K. H., Haas, R. M.
+#    Pubname: not applicable because source is not a journal
+#    Year: 1960
+#    Volume: 64(11)
+#    Page: 1764-1766
+#    Doi: 10.1021/j100840a505
+
+# GIE/LEN2000
+#    Type: Article
+#    Language: English
+#    Title: The crystal structure of nesquehonite, MgCO3·3H2O, from Lavrion, Greece
+#    Author: Giester, G., Lengauer, C. L., Rieck, B.
+#    Pubname: Mineralogy and Petrology
+#    Year: 2000
+#    Volume: 70(3-4)
+#    Page: 153-163
+#    Publisher: Springer Science and Business Media {LLC}
+#    Doi: 10.1007/s007100070001
+
+# GLU/MED1981
+#    Type: Book
+#    Language: Russian
+#    Title: Termičeskie konstanty veščestv. Bypusk X. Čast pervaja. Tablicy prinjatych značenij Li, Na
+#    Author: Glusko, V. N., Medvedev, V. A.
+#    Pubname: not applicable because source is not a journal
+#    Year: 1981
+#    Publisher: Moskva: Akademija Nauk SSSR
+
+# GLU/MED1981a
+#    Type: Book
+#    Language: Russian
+#    Title: Termičeskie konstanty veščestv. Bypusk X. Čast vtoraja. Tablicy prinjatych značenij K, Rb, Cs, Fr
+#    Author: Glusko, V. N., Medvedev, V. A.
+#    Pubname: not applicable because source is not a journal
+#    Year: 1981
+#    Publisher: Moskva: Akademija Nauk SSSR
+
+# GOR/BUR2008
+#    Type: Article
+#    Language: English
+#    Title: Review of uranyl mineral solubility measurements
+#    Author: Burns, P. C., Fein, J. B., Gorman-Lewis, D.
+#    Pubname: Journal of Chemical Thermodynamics
+#    Year: 2008
+#    Volume: 40
+#    Page: 335-352
+#    Doi: 10.1016/j.jct.2007.12.004
+#    Puburl: http://www.sciencedirect.com/science/article/B6WHM-4RDS1V8-1/2/434aa8f9bcd36c0068b5acd4641528c1
+
+# GOR/FEI2008
+#    Type: Article
+#    Language: English
+#    Title: Solubility measurements of the uranyl oxide hydrate phases metaschoepite, compreignacite, Na-compreignacite, becquerelite, and clarkeite
+#    Author: Burns, P. C., Converse, J., Fein, J. B., Gorman-Lewis, D., Szymanowski, J. E. S.
+#    Pubname: Journal of Chemical Thermodynamics
+#    Year: 2008
+#    Volume: 40
+#    Page: 980-990
+#    Doi: 10.1016/j.jct.2008.02.006
+#    Puburl: http://www.sciencedirect.com/science/article/pii/S0021961408000426ttp://www.sciencedirect.com/science/article/B6WHM-4RW43BP-3/2/8053c8459b4ca70d64e52142d205fde6
+
+# GOR/MAZ2007
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamic properties of soddyite from solubility and calorimetry measurements
+#    Author: Burns, P. C., Fein, J. B., Gorman-Lewis, D., Mazeina, L., Navrotsky, A., Szymanowski, J. E. S.
+#    Pubname: Journal of Chemical Thermodynamics
+#    Year: 2007
+#    Volume: 39
+#    Page: 568-575
+#    Doi: 10.1016/j.jct.2006.09.005
+#    Puburl: http://www.sciencedirect.com/science/article/pii/S0021961406001996
+
+# GRE/FUG1992
+#    Type: Book
+#    Language: English
+#    Title: Chemical Thermodynamics of Uranium
+#    Author: Fuger, J., Grenthe, I., Konings, R. J. M., Lemire, R. J., Muller, A. B., Nguyen-Trung, C., Wanner, H.
+#    Editors: H. Wanner and I. Forest
+#    Pubname: not applicable because source is not a journal
+#    Year: 1992
+#    Publisher: Elsevier Science Publ.
+#    Location: North-Holland, Amsterdam
+
+# GRE/GAO2020
+#    Type: Book
+#    Language: English
+#    Title: Second update on the chemical thermodynamics of uranium, neptunium, plutonium, americium and technetium. Chemical thermodynamics
+#    Author: Gaona, X., Grambow, B., Grenthe, I., Konings, R. J. M., Moore, E. E., Plyasunov, A. V., Rao, L., Runde, W., Smith, A.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2020
+#    Volume: 14
+#    Page: 1572
+#    Publisher: OECD Publishing
+#    Puburl: https://www.oecd-nea.org/upload/docs/application/pdf/2020-10/7500_second_update_of_u_np_pu_am_and_tc_web.pdf
+#    Location: Paris (France)
+
+# GRO1908
+#    Type: Book
+#    Language: German
+#    Title: Chemische Krystallographie - Die Anorganischen Oxo- und Sulfosalze (Zweiter Teil)
+#    Author: Groth, P.
+#    Pubname: not applicable because source is not a journal
+#    Year: 1908
+#    Publisher: Verlag Wilhelm Engelmann, Leipzig
+
+# GUI/FAN2003
+#    Type: Book
+#    Language: English
+#    Title: UPDATE ON THE CHEMICAL THERMODYNAMICS OF URANIUM. NEPTUNIUM. PLUTONIUM. AMERICIUM AND TECHNETIUM
+#    Author: Ben-Said, K., Domenech-Orti, C., Fanghänel, T., Fuger, J., Grenthe, I., Guillaumont, R., Illemassene, M., Mompean, F. J., Neck, V., Palmer, D. A., Rand, M. H.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2003
+#    Publisher: NUCLEAR ENERGY AGENCY ORGANISATION FOR ECONOMIC CO-OPERATION AND DEVELOPMENT
+#    Puburl: http://www.oecd-nea.org/dbtdb/pubs/vol5-update-combo.pdf
+#    Location: Issy-les-Moulineaux (France)
+
+# GUN/ARN2000
+#    Type: Article
+#    Language: English
+#    Title: Amorphous silica solubility and the thermodynamic properties of H4SiO4° in the range of 0° to 350°C at psat
+#    Author: Arnórsson, S., Gunnarsson, I.
+#    Pubname: Geochimica et Cosmochimica Acta
+#    Year: 2000
+#    Volume: 64(13)
+#    Page: 2295-2307
+#    Doi: 10.1016/S0016-7037(99)00426-3
+#    Puburl: http://www.sciencedirect.com/science/article/pii/S0016703799004263
+
+# GUO/SZE2015
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamics of formation of coffinite, USiO4
+#    Author: Bosbach, D., Burns, P. C., Clavier, N., Curtius, H., Dacheux, N., Ewing, R. C., Guo, X.-F., Labs, S., Mesbah, A., Poinssot, C., Szenknect, S., Ushakov, S. V.
+#    Pubname: Proceedings of the National Academy of Sciences of the United States
+#    Year: 2015
+#    Volume: 112
+#    Page: 6551-6555
+#    Doi: 10.1073/pnas.1507441112
+#    Puburl: www.pnas.org/cgi/doi/10.1073/pnas.1507441112
+
+# HAG/MOO2012
+#    Type: Report
+#    Language: German
+#    Title: Rückhaltung und thermodynamische Modellierung von Iod und Selen in hochsalinaren Lösungen
+#    Author: Erich, A., Hagemann, S., Herbert, H.-J., Moog, H. C.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2012
+#    Page: 176
+#    Publisher: Gesellschaft für Anlagen- und Reaktorsicherheit (GRS) mbH
+
+# HAG1999
+#    Type: Ph.D. thesis
+#    Language: German
+#    Title: Thermodynamische Eigenschaften des Bleis in Lösungen der ozeanischen Salze
+#    Author: Hagemann, S.
+#    Pubname: not applicable because source is not a journal
+#    Year: 1999
+#    Doi: 10.24355/dbbs.084-200511080100-200
+#    Puburl: https://publikationsserver.tu-braunschweig.de/receive/dbbs_mods_00001107
+
+# HAG2022
+#    Type: Report
+#    Language: English
+#    Title: Development of a thermodynamic model for zinc, lead and cadmium in saline solutions
+#    Author: Hagemann, S.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2022
+#    Volume: GRS-653
+#    Puburl: https://www.grs.de/sites/default/files/2024-04/GRS-653.pdf
+
+# HAG2024
+#    Type: Report
+#    Language: English
+#    Title: Development of a Thermodynamic Model for Zinc, Lead and Cadmium in Saline Solutions
+#    Author: Hagemann, S.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2024
+#    Page: 482
+#    Publisher: GRS gGmbH
+
+# HAR/MOL1984
+#    Type: Article
+#    Language: English
+#    Title: The prediction of mineral solubilities in natural waters: Na-K-Mg-Ca-H-Cl-SO4-OH-HCO3-CO3-CO2-H2O system to high ionic strengths at 25°C
+#    Author: Harvie, C. E., Møller, N., Weare, J. H.
+#    Pubname: Geochimica et Cosmochimica Acta
+#    Year: 1984
+#    Volume: 48(4)
+#    Page: 723-751
+#    Publisher: Elsevier Ltd.
+#    Doi: 10.1016/0016-7037(84)90098-X
+#    Puburl: http://www.sciencedirect.com/science/article/pii/001670378490098X
+
+# HAR1989
+#    Type: Article
+#    Language: English
+#    Title: On the unit cell dimensions and bond lengths of anhydrite
+#    Author: Hartman, P.
+#    Pubname: European Journal of Mineralogy
+#    Year: 1989
+#    Volume: 1(5)
+#    Page: 721-722
+
+# HAU/SCH2019
+#    Type: Article
+#    Language: English
+#    Title: Calcium Hydroxide Chlorides: The Ternary System Ca(OH)2-CaCl2-H2O at 25, 40 and 60 °C, Phase Stoichiometry and Crystal Structure
+#    Author: Freyer, D., Häusler, F., Schmidt, H.
+#    Pubname: Zeitschrift für Anorganische und Allgemeine Chemie
+#    Year: 2019
+#    Volume: 645
+#    Page: 723-731
+#    Publisher: Wiley
+#    Doi: 10.1002/zaac.201900051
+
+# HAW/FER1975
+#    Type: Article
+#    Language: English
+#    Title: Anhydrous sulfates. I. Refinement of the crystal structure of celestite with an appendix on the structure of thenardite
+#    Author: Ferguson, R. B., Hawthorne, F. C.
+#    Pubname: Canadian Mineralogist
+#    Year: 1975
+#    Volume: 13(2)
+#    Page: 181-187
+
+# HEM1982
+#    Type: Report
+#    Language: English
+#    Title: Thermodynamic properties of selected uranium compounds and aqueous species at 298.15 K and 1 bar and at higher temperatures - Preliminary models for the origin of coffinite deposits
+#    Author: Hemingway, B. S.
+#    Pubname: not applicable because source is not a journal
+#    Year: 1982
+#    Publisher: U.S. Geological Survey
+#    Puburl: http://pubs.usgs.gov/of/1982/0619/report.pdf
+
+# HER/GAO2015
+#    Type: Article
+#    Language: English
+#    Title: Solubility and spectroscopic study of AnIII/LnIII in dilute to concentrated Na–Mg–Ca–Cl–NO3 solutions
+#    Author: Altmaier, M., Crepin, C., Dardenne, K., Fellhauer, D., Gaona, X., Geckeis, H., Herm, M., Rabung, T.
+#    Pubname: Pure and Applied Chemistry
+#    Year: 2015
+#    Volume: 87
+#    Page: 487-502
+#    Doi: 10.1515/pac-2014-1205
+
+# HER/GIE2001
+#    Type: Article
+#    Language: English
+#    Title: The crystal structures of the low-temperature phases of leonite-type compounds, K2Me(SO4)2·4H2O (Me2+ = Mg, Mn, Fe)
+#    Author: Giester, G., Hertweck; B., Libowitzky, E.
+#    Pubname: American Mineralogist
+#    Year: 2001
+#    Volume: 86(10)
+#    Page: 1282-1292
+#    Publisher: Mineralogical Society of America
+#    Doi: 10.2138/am-2001-1016
+
+# HES/XIA2004
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamic Model for the Solubility of TcO2·xH2O(am) in the Aqueous Tc(IV)-Na+-Cl--H+-OH-H2O System
+#    Author: Conradson, S. D., Hess, N. J., Rai, D., Xia, Y.
+#    Pubname: Journal of Solution Chemistry
+#    Year: 2004
+#    Volume: 33(2)
+#    Page: 199-226
+#    Publisher: Springer
+#    Doi: 10.1023/B:JOSL.0000030285.11512.1f
+#    Puburl: http://www.springerlink.com/content/t40r6674rw3533x7/
+
+# HUM/BER2002
+#    Type: Book
+#    Language: English
+#    Title: Nagra/PSI Chemical Thermodynamic Data Base 01/01
+#    Author: Berner, U., Curti, E., Hummel, W., Pearson, F. J., Thoenen, T.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2002
+#    Publisher: Universal Publishers
+#    Location: Florida, USA
+
+# HUM/THO2023
+#    Type: Report
+#    Language: English
+#    Title: The PSI Chemical Thermodynamic Database 2020
+#    Author: Hummel, W., Thoenen, T.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2023
+#    Publisher: Nagra
+#    Puburl: https://nagra.ch/downloads/technical-report-ntb-23-04/
+#    Location: Wettingen
+
+# JAC2009
+#    Type: Report
+#    Language: English
+#    Title: Benchmarking of the cement model and detrimental chemical reactions including temperature dependent parameters
+#    Author: Jacques, D.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2009
+#    Page: 121
+#    Publisher: ONDRAF/NIRAS
+#    Puburl: NIROND-TR 2008-30E
+#    Location: Brussels (B)
+
+# KIE/FEL2025
+#    Type: Article
+#    Language: English
+#    Title: Improved Pitzer activity model for Tc(IV) solubility and hydrolysis in the Tc(IV)–Na+ –K+ –Ca2+–Mg2+– H+ –Cl−–OH−–H2O(l) system
+#    Author: Altmaier, M., Fellhauer, D., Gaona, X., Kiefer, C.
+#    Pubname: RSC Advances
+#    Year: 2025
+#    Volume: 15
+#    Page: 37816
+#    Doi: 10.1039/d5ra04721h
+
+# KON/FAN1997
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamics of Trivalent Actinides in Concentrated Electrolyte Solutions: Modelling of the Chloride Complexation of Cm(III)
+#    Author: Fanghänel, T., Kim, J. I., Könnecke, T.
+#    Pubname: Radiochimica Acta
+#    Year: 1997
+#    Volume: 76
+#    Page: 131-135
+#    Doi: 10.1524/ract.1997.76.3.131
+
+# KON/NEC1997
+#    Type: Article
+#    Language: English
+#    Title: Activity coefficients and Pitzer parameters in the systems Na+/Cs+/Cl-/TcO4- or ClO4-/H2O at 25 degrees C
+#    Author: Fanghänel, T., Kim, J. I., Könnecke, T., Neck, V.
+#    Pubname: Journal of Solution Chemistry
+#    Year: 1997
+#    Volume: 26
+#    Page: 561 - 577
+#    Doi: 10.1007/BF02767628
+
+# KUB/HEL2006
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamics of uranyl minerals: Enthalpy of formation of uranyl oxide hydrates
+#    Author: Burns, P. C., Helean, K., Kubatko, K. A., Navrotsky, A.
+#    Pubname: American Mineralogist
+#    Year: 2006
+#    Volume: 91
+#    Page: 658-666
+#    Doi: 10.2138/am.2006.1856
+#    Puburl: http://ammin.geoscienceworld.org/cgi/content/abstract/91/4/658
+
+# KUL/KER2001
+#    Type: Article
+#    Language: English
+#    Title: Aqueous Solubility Diagrams for Cementitious Waste Stabilization Systems: II, End-Member Stoichiometries of Ideal Calcium Silicate Hydrate Solid Solutions
+#    Author: Kersten, M., Kulik, D. A.
+#    Pubname: Journal of the American Ceramic Society
+#    Year: 2001
+#    Volume: 84
+#    Page: 3017-3026
+#    Doi: 10.1111/j.1151-2916.2001.tb01130.x
+
+# KUL/TIT2007
+#    Type: Article
+#    Language: English
+#    Title: Aqueous-solid solution model of strontium uptake in C-S-H phases
+#    Author: Kulik, D. A., Tits, J., Wieland, E.
+#    Pubname: Geochimica et Cosmochimica Acta
+#    Year: 2007
+#    Volume: 71(15) Supplement
+#    Page: A530
+#    Doi: 10.1016/j.gca.2007.06.019
+
+# KUL2011
+#    Type: Article
+#    Language: English
+#    Title: Improving the structural consistency of C-S-H solid solution thermodynamic models
+#    Author: Kulik, D. A.
+#    Pubname: Cement and Concrete Research
+#    Year: 2011
+#    Volume: 41
+#    Page: 477-495
+#    Doi: 10.1016/j.cemconres.2011.01.012
+
+# LAC/AND2018
+#    Type: Article
+#    Language: English
+#    Title: A Pitzer Parametrization To Predict Solution Properties and Salt Solubility in the H−Na−K−Ca−Mg−NO3−H2O System at 298.15 K
+#    Author: André, L., Christov, C., Guignot, S., Henocq, P., Lach, A., Lassin, A.
+#    Pubname: Journal of Chemical and Engineering Data
+#    Year: 2018
+#    Volume: 63
+#    Page: 787-800
+#    Doi: 10.1021/acs.jced.7b00953
+
+# LAN1978
+#    Type: Article
+#    Language: English
+#    Title: Uranium solution-mineral equilibria at low temperatures with applications to sedimentary ore deposits
+#    Author: Langmuir, D.
+#    Pubname: Geochimica et Cosmochimica Acta
+#    Year: 1978
+#    Volume: 42(6) Part A
+#    Page: 547-569
+#    Publisher: Elsevier Ltd.
+#    Doi: 10.1016/0016-7037(78)90001-7
+#    Puburl: http://www.sciencedirect.com/science/article/pii/0016703778900017
+
+# LEM/BER2013
+#    Type: Book
+#    Language: English
+#    Title: CHEMICAL THERMODYNAMICS OF IRON PART 1
+#    Author: Berner, U., Lemire, R. J., Musikas, C., Palmer, D. A., Taylor, P., Tochiyama, O.
+#    Editors: Perrone, J.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2013
+#    Volume: 13a
+#    Page: 1126
+#    Publisher: OECD Nuclear Energy Agency
+#    Puburl: www.oecd-nea.org/dbtdb/pubs/6355-vol13a-iron.pdf
+#    Location: Issy-les-Moulineaux (France)
+
+# LEM/FUG2001
+#    Type: Book
+#    Language: English
+#    Title: Chemical Thermodynamics Vol. 4. Chemical Thermodynamics of Neptunium and Plutonium
+#    Author: Fuger, J., Lemire, R. J., Nitsche, H., Potter, P., Rand, M. H., Rydberg, J., Spahiu, K., Sullivan, J. C., Ullman, W. J., Vitorge, P., Wanner, H.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2001
+#    Volume: 4
+#    Page: 872
+#    Publisher: Elsevier Science Publ.
+#    Location: North-Holland, Amsterdam
+
+# LIU/ZHO1990
+#    Type: Article
+#    Language: English
+#    Title: Synthesis of lansfordite MgCO3·5H2O and its crystal structure investigation
+#    Author: Cui, X. S., Liu, B. N., Tang, J. G., Zhou, X. T.
+#    Pubname: Science in China Series B (Chemistry, Life Science, & Earth Science)
+#    Year: 1990
+#    Volume: 33(11)
+#    Page: 1350-1356
+
+# LOT/KUL2019
+#    Type: Article
+#    Language: English
+#    Title: Cemdata18: A chemical thermodynamic database for hydrated Portland cements and alkali-activated materials
+#    Author: Balonis, M., Baquerizo, L. G., Dilnesa, B. Z., Kulik, D. A., Lothenbach, B., Matschei, T., Miron, G. D., Myers, R. J.
+#    Pubname: Cement and Concrete Research
+#    Year: 2019
+#    Volume: 115
+#    Page: 472-506
+#    Doi: 10.1016/j.cemconres.2018.04.018
+
+# LOT/MAT2008
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamic modelling of the effect of temperature on the hydration and porosity of Portland cement
+#    Author: Glasser, F. P., Lothenbach, B., Matschei, T., Moschner, G.
+#    Pubname: Cement and Concrete Research
+#    Year: 2008
+#    Volume: 38
+#    Page: 1-18
+#    Doi: 10.1016/j.cemconres.2007.08.017
+#    Puburl: http://www.sciencedirect.com/science/article/pii/S0008884607001998
+
+# LOT/PEL2012
+#    Type: Article
+#    Language: English
+#    Title: Stability in the system CaO-Al2O3-H2O
+#    Author: Lothenbach, B., Pelletier-Chaignat, L., Winnefeld, F.
+#    Pubname: Cement and Concrete Research
+#    Year: 2012
+#    Volume: 42
+#    Page: 1621-1634
+#    Doi: 10.1016/j.cemconres.2012.09.002
+#    Puburl: http://www.sciencedirect.com/science/article/pii/S0008884612001949
+
+# MAR/GAO2014
+#    Type: Report
+#    Language: English
+#    Title: THEREDA - Final Report Part KIT-INE - Database for Radionuclides
+#    Author: Altmaier, M., Bube, C., Gaona, X., Marquardt, C.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2014
+#    Page: 111
+
+# MAS/STR1995
+#    Type: Article
+#    Language: English
+#    Title: Electron density and optical anisotropy in rhombohedral carbonates. III. Synchrotron X-ray studies of CaCO3, MgCO3 and MnCO3
+#    Author: Ishizawa, N., Maslen, E. N., Streltsov, V. A., Streltsova, N. R.
+#    Pubname: Acta Crystallographica, Section B: Structural Science
+#    Year: 1995
+#    Volume: 51(6)
+#    Page: 929-939
+#    Doi: 10.1107/s0108768195006434
+
+# MAT/GLA2015
+#    Type: Article
+#    Language: English
+#    Title: Thermal stability of thaumasite
+#    Author: Glasser, F. P., Matschei, T.
+#    Pubname: Materials and Structures
+#    Year: 2015
+#    Volume: 48
+#    Page: 2277–2289
+#    Doi: 10.1617/s11527-014-0309-4
+#    Puburl: http://link.springer.com/article/10.1617/s11527-014-0309-4
+
+# MAT/LOT2007
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamic properties of Portland cement hydrates in the system CaO-Al2O3-SiO2-CaSO4-CaCO3-H2O
+#    Author: Glasser, F. P., Lothenbach, B., Matschei, T.
+#    Pubname: Cement and Concrete Research
+#    Year: 2007
+#    Volume: 37(10)
+#    Page: 1379-1410
+#    Doi: 10.1016/j.cemconres.2007.06.002
+#    Puburl: http://www.sciencedirect.com/science/article/pii/S0008884607001299#
+
+# MCG1972
+#    Type: Article
+#    Language: English
+#    Title: Redetermination of the structures of potassium sulphate and potassium chromate: the effect of electrostatic crystal forces upon observed bond lengths
+#    Author: McGinnety, J. A.
+#    Pubname: Acta Crystallographica, Section B: Structural Science
+#    Year: 1972
+#    Volume: 28(9)
+#    Page: 2845-2852
+#    Doi: 10.1107/s0567740872007022
+
+# MIR2023
+#    Type: Report
+#    Language: English
+#    Title: Consistent set of Pitzer activity model interaction parameters of Al and Si species, for modelling cements in saline systems with THEREDA
+#    Author: Miron, G. D.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2023
+
+# MOO2022
+#    Type: THEREDA-Journal
+#    Language: English
+#    Title: Thermodynamic database for Pb and its compounds - data selection
+#    Author: Moog, H. C.
+#    Pubname: THEREDA Journal
+#    Year: 2022
+#    Volume: 2(1)
+#    Page: 1-29
+#    Publisher: THEREDA
+#    Puburl: https://nbn-resolving.org/urn:nbn:de:bsz:105-qucosa2-802332
+#    Location: Freiberg
+
+# MUN2024
+#    Type: Report
+#    Language: English
+#    Title: Thermodynamics and activity of nitrate salts in highly concentrated geological brines
+#    Author: Munoz, A. G.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2024
+
+# MUT1965
+#    Type: Article
+#    Language: English
+#    Title: Thermochemical stability of ningyoite
+#    Author: Muto, T.
+#    Pubname: Mineralogical Magazine
+#    Year: 1965
+#    Volume: 4
+#    Page: 245-274
+
+# MYE/BER2014
+#    Type: Article
+#    Language: English
+#    Title: A thermodynamic model for C-(N-)A-S-H gel: CNASH_ss. Derivation and validation
+#    Author: Bernal, S. A., Myers, R. J., Provis, J. L.
+#    Pubname: Cement and Concrete Research
+#    Year: 2014
+#    Volume: 66
+#    Page: 27-47
+#    Doi: 10.1016/j.cemconres.2014.07.005
+
+# MYE/LOT2015
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamic modelling of alkali-activated slag cements
+#    Author: Bernal, S. A., Lothenbach, B., Myers, R. J., Provis, J. L.
+#    Pubname: Applied Geochemistry
+#    Year: 2015
+#    Volume: 61
+#    Page: 233-247
+#    Doi: 10.1016/j.apgeochem.2015.06.006
+
+# NEC/ALT2009
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamics of trivalent actinides and neodymium in NaCl, MgCl2 and CaCl2 solutions: Solubility, hydrolysis and ternary Ca-M(III)-OH complexes
+#    Author: Altmaier, M., Fanghänel, T., Neck, V., Rabung, T.
+#    Pubname: Pure and Applied Chemistry
+#    Year: 2009
+#    Volume: 81(9)
+#    Page: 1555-1568
+#    Publisher: IUPAC
+#    Doi: 10.1351/PAC-CON-08-09-05
+#    Puburl: http://iupac.org/publications/pac/81/9/1555/
+
+# NEC/FAN1998
+#    Type: Report
+#    Language: German
+#    Title: Aquatische Chemie und thermodynamische Modellierung von trivalenten Actiniden
+#    Author: Fanghänel, T., Kim, J. I., Neck, V.
+#    Pubname: not applicable because source is not a journal
+#    Year: 1998
+#    Publisher: Forschungszentrum Karlsruhe
+#    Location: Karlsruhe
+
+# NEC/FAN2001
+#    Type: Report
+#    Language: German
+#    Title: Kenntnisstand zur aquatischen Chemie und der thermodynamischen Datenbasis von Actiniden und Technetium
+#    Author: Fanghänel, T., Kienzler, B., Metz, V., Neck, V.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2001
+#    Publisher: Institut für Nukleare Entsorgung. Forschungszentrum Karlsruhe GmbH
+#    Location: Karlsruhe
+
+# NEC/KIM2001
+#    Type: Article
+#    Language: English
+#    Title: Solubility and Hydrolysis of Tetravalent Actinides
+#    Author: Kim, J. I., Neck, V.
+#    Pubname: Radiochimica Acta
+#    Year: 2001
+#    Volume: 89
+#    Page: 1-16
+#    Publisher: Oldenbourg Wissenschaftsverlag
+#    Doi: 10.1524/ract.2001.89.1.001
+#    Puburl: http://www.degruyter.com/view/j/ract.2001.89.issue-1_2001/ract.2001.89.1.001/ract.2001.89.1.001.xml
+#    Location: München
+
+# NEC/KON1998
+#    Type: Article
+#    Language: English
+#    Title: Pitzer Parameters for the Pertechnetate Ion in the System Na+/K+/Mg2+/Ca2+/Cl-/SO2-/TcO-4/H2O at 25°C
+#    Author: Fanghänel, T., Kim, J. I., Könnecke, T., Neck, V.
+#    Pubname: Journal of Solution Chemistry
+#    Year: 1998
+#    Volume: 27
+#    Page: 107-120
+#    Doi: 10.1023/A:1022664013648
+
+# NEC1997
+#    Type: Report
+#    Language: German
+#    Title: Kenntnisstand zur aquatischen Chemie und Thermodynamik von pentavalenten Actiniden
+#    Author: Neck, V.
+#    Pubname: not applicable because source is not a journal
+#    Year: 1997
+
+# NEC2000
+#    Type: Report
+#    Language: German
+#    Title: Kenntnisstand zur aquatischen Chemie und Thermodynamik von tetravalenten Actiniden
+#    Author: Neck, V.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2000
+#    Page: 87
+#    Publisher: Institut für Nukleare Entsorgung
+
+# NGU/SIL1992
+#    Type: Article
+#    Language: English
+#    Title: Standard Gibbs free energies of formation at the temperature 303.15 K of four uranyl silicates: soddyite, uranophane, sodium boltwoodite, and sodium weeksite
+#    Author: Andrews Jr., J. E., Nguyen, S. N., Silva, R. J., Weed, H. C.
+#    Pubname: Journal of Chemical Thermodynamics
+#    Year: 1992
+#    Volume: 24(4)
+#    Page: 359-376
+#    Publisher: Elsevier Ltd.
+#    Doi: 10.1016/S0021-9614(05)80155-7
+#    Puburl: http://www.sciencedirect.com/science/article/pii/S0021961405801557
+
+# NIE/ENE2016
+#    Type: Article
+#    Language: English
+#    Title: Properties of magnesium silicate hydrates (M-S-H)
+#    Author: Enemark-Rasmussen, K., LHopital, E. L., Lothenbach, B., Nied, D., Skibsted, J.
+#    Pubname: Cement and Concrete Research
+#    Year: 2016
+#    Volume: 79
+#    Page: 323-332
+#    Doi: 10.1016/j.cemconres.2015.10.003
+
+# NOV/MAH1997
+#    Type: Article
+#    Language: English
+#    Title: Measurement and Thermodynamic Modeling of Np(V) Solubility in Aqueous K2CO3 Solutions to High Concentrations
+#    Author: AlMahamid, I., Becraft, K. A., Carpenter, S. A., Hakem, N., Novak, C. F., Prussin, T.
+#    Pubname: Journal of Solution Chemistry
+#    Year: 1997
+#    Volume: 26(7)
+#    Page: 681-697
+#    Publisher: Springer
+#    Doi: 10.1007/BF02767621
+#    Puburl: http://www.springerlink.com/content/t272827484215j11/
+
+# OBR/WIL1983
+#    Type: Article
+#    Language: English
+#    Title: The aqueous chemistry of uranium minerals. 4. Schröckingerite, grimselite, and related alkali uranyl carbonates
+#    Author: Williams, P. A.
+#    Pubname: Mineralogical Magazine
+#    Year: 1983
+#    Volume: 47(342)
+#    Page: 69-73
+#    Doi: 10.1180/minmag.1983.047.342.12
+
+# OET/RAN1976
+#    Type: Book
+#    Language: English
+#    Title: The Chemical Thermodynamics of Actinide Elements and Compounds Part 1. The Actinide Elements
+#    Author: Ackermann, R. J., Oetting, F. L., Rand, M. H.
+#    Pubname: not applicable because source is not a journal
+#    Year: 1976
+#    Publisher: IAEA, International Atomic Energy Agency
+#    Location: Vienna
+
+# OLI/NOL2005
+#    Type: Book
+#    Language: English
+#    Title: Chemical Thermodynamics of Selenium, Volume 7
+#    Author: Noläng, B., Oehman, L.-O., Olin, A., Osadchii, E. G., Rosen, E.
+#    Editors: Mompean, F. J.; Perrone, J.; Illemassene, M.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2005
+#    Volume: 7
+#    Page: 894
+#    Publisher: Elsevier Science
+
+# PAN/CAM1998
+#    Type: Article
+#    Language: English
+#    Title: The Characterization of Np2O5(c) and its Dissolution in CO2-free Aqueous Solution at pH 6 to 13 at 25°C
+#    Author: Campbell, A. B., Pan, P.
+#    Pubname: Radiochimica Acta
+#    Year: 1998
+#    Volume: 81
+#    Page: 73-82
+#    Publisher: R. Oldenbuurg Verlag
+#    Doi: 10.1524/ract.1998.81.2.73
+#    Location: München
+
+# PAN2019
+#    Type: Ph.D. thesis
+#    Language: German
+#    Title: Löslichkeitsgleichgewichte basischer Magnesiumchlorid- und Magnesiumsulfat-Hydrate in wässrigen Lösungen bei 25 °C bis 120 °C
+#    Author: Pannach, M.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2019
+#    Volume: 1
+#    Page: 185
+#    Publisher: TU Bergakademie Freiberg
+#    Puburl: http://nbn-resolving.de/urn:nbn:de:bsz:105-qucosa2-334824
+#    Location: Freiberg (D)
+
+# PAS/CZE1997
+#    Type: Article
+#    Language: English
+#    Title: Solid-liquid phase equilibria of Pu(VI) and U(VI) in aqueous carbonate systems. Determination of stability constants
+#    Author: Czerwinski, K. R., Fanghänel, T., Kim, J. I., Pashalidis, I.
+#    Pubname: Radiochimica Acta
+#    Year: 1997
+#    Volume: 76
+#    Page: 55-62
+#    Publisher: Oldenbourg Wissenschaftsverlag
+#    Location: Munich
+
+# PAU/KHR1968
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamic functions of caesium sulphate at low temperatures
+#    Author: Khriplovich, L. M., Korotkikh, A. M., Paukov, I. E.
+#    Pubname: Russian Journal of Physical Chemistry
+#    Year: 1968
+#    Volume: 42(5)
+#    Page: 661-662
+
+# PED/SEM1982
+#    Type: Article
+#    Language: English
+#    Title: Neutron diffraction refinement of the structure of gypsum, CaSO4·2H2O
+#    Author: Pedersen, B. F., Semmingsen, D.
+#    Pubname: Acta Crystallographica B
+#    Year: 1982
+#    Volume: 38(4)
+#    Page: 1074-1077
+#    Publisher: International Union of Crystallography ({IUCr})
+#    Doi: 10.1107/s0567740882004993
+
+# PIT/MAY1973
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamics of electrolytes: II: Activity and osmotic coefficients for strong electrolytes with one or both ions univalent
+#    Author: Mayorga, G., Pitzer, K. S.
+#    Pubname: Journal of Physical Chemistry
+#    Year: 1973
+#    Volume: 77
+#    Page: 2300-2308
+#    Doi: 10.1021/j100638a009
+#    Puburl: http://pubs.acs.org/doi/pdf/10.1021/j100638a009
+
+# PIT/MAY1974
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamics of electrolytes. III. Activity and osmotic coefficients for 2-2 electrolytes
+#    Author: Mayorga, G., Pitzer, K. S.
+#    Pubname: Journal of Solution Chemistry
+#    Year: 1974
+#    Volume: 3
+#    Page: 539-546
+#    Doi: 10.1007/bf00648138
+#    Puburl: http://www.springerlink.com/content/q7525v726824v381/fulltext.pdf
+
+# PIT1991
+#    Type: Book
+#    Language: English
+#    Title: Activity Coefficients in Electrolyte Solutions
+#    Author: Pitzer, K. S.
+#    Pubname: not applicable because source is not a journal
+#    Year: 1991
+#    Page: 542
+#    Publisher: CRC Press
+#    Edition: 2
+#    Location: Boca Raton, Florida, USA
+
+# PLY/FAN1998
+#    Type: Article
+#    Language: English
+#    Title: Estimation of the Pitzer equation parameters for aqueous complexes. A case study for uranium at 298.15 K and 1 atm
+#    Author: Fanghänel, T., Grenthe, I., Plyasunov, A. V.
+#    Pubname: Acta Chemica Scandinavica
+#    Year: 1998
+#    Volume: 52
+#    Page: 250-260
+#    Doi: 10.3891/acta.chem.scand.52-0250
+#    Puburl: http://actachemscand.dk/pdf/acta_vol_52_p0250-0260.pdf
+
+# POK/SCH1996
+#    Type: Article
+#    Language: English
+#    Title: The stability of aluminum silicate complexes in acidic solutions from 25 to 150°C
+#    Author: Harrichoury, J. C., Pokrovski, G.S., Schott, J., Sergeyev, A. S.
+#    Pubname: Geochimica et Cosmochimica Acta
+#    Year: 1996
+#    Volume: 60
+#    Page: 2495-2501
+#    Doi: 10.1016/0016-7037(96)00123-8
+
+# POL/PRA2001
+#    Type: Book
+#    Language: English
+#    Title: The Properties of Gases and Liquids
+#    Author: Poling, B. E., Prausnitz, J. M.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2001
+#    Publisher: McGraw-Hill Education
+#    Puburl: https://www.accessengineeringlibrary.com/content/book/9780070116825
+#    Edition: 5th
+#    Location: New York
+
+# RAB/ALT2008
+#    Type: Article
+#    Language: English
+#    Title: A TRLFS study of Cm(III) hydroxide complexes in alkaline CaCl2 solutions
+#    Author: Altmaier, M., Fanghänel, T., Neck, V., Rabung, T.
+#    Pubname: Radiochimica Acta
+#    Year: 2008
+#    Volume: 96
+#    Page: 551-559
+#    Publisher: Oldenbourg Wissenschaftsverlag
+#    Doi: 10.1524/ract.2008.1536
+#    Puburl: http://www.degruyter.com/view/j/ract.2008.96.issue-9-11/ract.2008.1536/ract.2008.1536.xml
+#    Location: Munich
+
+# RAI/FEL1998
+#    Type: Article
+#    Language: English
+#    Title: A Thermodynamic Model for the Solubility of UO2(am) in the Aqueous K+ / Na+ / HCO3- / CO32- / OH- / H2O System
+#    Author: Felmy, A. R., Hess, N. J., Moore, D. A., Rai, D., Yui, M.
+#    Pubname: Radiochimica Acta
+#    Year: 1998
+#    Volume: 82
+#    Page: 17-25
+#    Publisher: Oldenbourg Wissenschaftsverlag
+#    Doi: 10.1524/ract.1998.82.special-issue.17
+#    Location: Munich
+
+# RAI/HES1999
+#    Type: Article
+#    Language: English
+#    Title: A Thermodynamic Model for the Solubility of NpO2(am) in the Aqueous K+-HCO3--CO32--OH--H2O System
+#    Author: Felmy, A. R., Hess, N. J., Moore, D. A., Rai, D., Yui, M.
+#    Pubname: Radiochimica Acta
+#    Year: 1999
+#    Volume: 84
+#    Page: 159-169
+#    Publisher: Oldenbourg Wissenschaftsverlag
+#    Doi: 10.1524/ract.1999.84.3.159
+#    Puburl: https://doi.org/10.1524/ract.1999.84.3.159
+#    Location: Munich
+
+# RAI/HES1999a
+#    Type: Article
+#    Language: English
+#    Title: A Thermodynamic Model for the Solubility of PuO2(am) in the Aqueous K+-HCO3--CO32--OH--H2O System
+#    Author: Felmy, A. R., Hess, N. J., Moore, D. A., Rai, D., Vitorge, P., Yui, M.
+#    Pubname: Radiochimica Acta
+#    Year: 1999
+#    Volume: 86(3-4)
+#    Page: 89-99
+#    Doi: 10.1524/ract.1999.86.34.89
+#    Puburl: https://doi.org/10.1524/ract.1999.86.34.89
+
+# RAI/MOO2000
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamic model for the solubility of thorium dioxide in the Na+-Cl--OH--H2O system at 23°C and 90°C
+#    Author: Moore, D. A., Oakes, C. S., Rai, D., Yui, M.
+#    Pubname: Radiochimica Acta
+#    Year: 2000
+#    Volume: 88
+#    Page: 297-306
+#    Publisher: Olndebourg Wissenschaftsverlag
+#    Doi: 10.1524/ract.2000.88.5.297
+#    Puburl: http://www.degruyter.com/view/j/ract.2000.88.issue-5_2000/ract.2000.88.5.297/ract.2000.88.5.297.xml
+#    Location: Munich
+
+# RAI/RAO1999
+#    Type: Report
+#    Language: English
+#    Title: Thermodynamic data for predicting concentrations of Th(IV), U(IV), Np(IV), and Pu(IV) in geologic environments
+#    Author: Choppin, G. R., Felmy, A. R., Rai, D., Rao, L., Weger, H., Yui, M.
+#    Editors: Pacific Northwest National Laboratory
+#    Pubname: not applicable because source is not a journal
+#    Year: 1999
+#    Page: 124
+#    Puburl: https://inis.iaea.org/collection/NCLCollectionStore/_Public/31/027/31027893.pdf
+
+# RAN/FUG2008
+#    Type: Book
+#    Language: English
+#    Title: Chemical Thermodynamics Vol. 11, Chemical Thermodynamics of Thorium
+#    Author: Fuger, J., Grenthe, I., Neck, V., Rai, D., Rand, M. H.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2008
+#    Volume: 11
+#    Page: 942
+#    Publisher: OECD Nuclear Energy Agency
+#    Puburl: https://www.oecd-nea.org/science/pubs/2007/6254-DB-chemical-thermodyn-11.pdf
+#    Location: Paris
+
+# RAR/RAN1999
+#    Type: Book
+#    Language: English
+#    Title: Chemical Thermodynamics Vol. 3 Chemical Thermodynamics of Technetium
+#    Author: Anderegg, G., Rand, M. H., Rard, J. A., Wanner, H.
+#    Pubname: not applicable because source is not a journal
+#    Year: 1999
+#    Volume: 3
+#    Page: 568
+#    Publisher: Elsevier Science Publ.
+#    Puburl: http://www.oecd-nea.org/dbtdb/pubs/vol3-technetium.pdf
+#    Edition: 1
+#    Location: North-Holland, Amsterdam
+
+# RAR1996
+#    Type: Article
+#    Language: English
+#    Title: Isopiestic determination of the osmotic coefficients of Lu2(SO4)3 (aq) and H2SO4(aq) at the temperature T=298.15 K, and review and revision of the thermodynamic properties of Lu2(SO4)3 (aq) and Lu2(SO4)3·8H2O (cr)
+#    Author: Rard, J. A.
+#    Pubname: Journal of Chemical Thermodynamics
+#    Year: 1996
+#    Volume: 28
+#    Page: 83-110
+#    Doi: 10.1006/jcht.1996.0008
+
+# REA1990
+#    Type: Article
+#    Language: English
+#    Title: An ion interaction model for the determination of chemical equilibria in cement/water systems
+#    Author: Reardon, E. J.
+#    Pubname: Cement and Concrete Research
+#    Year: 1990
+#    Volume: 20(2)
+#    Page: 175-192
+#    Publisher: Elsevier Ltd.
+#    Doi: 10.1016/0008-8846(90)90070-E
+#    Puburl: http://www.sciencedirect.com/science/article/pii/000888469090070E
+
+# ROS/KOC1968
+#    Type: Book
+#    Language: German
+#    Title: Salzmikroskopie
+#    Author: Koch, K., Rösler, H. J.
+#    Pubname: not applicable because source is not a journal
+#    Year: 1968
+#    Publisher: Freiberg Bergakademie
+
+# ROY/VOG1992
+#    Type: Article
+#    Language: English
+#    Title: Activity coefficients in electrolyte mixtures: HCl + ThCl4 + H2O for 5-55°C
+#    Author: Davis, W. B., Felmy, A. R., Good, C. E., Johnson, D. A., Pitzer, K. S., Roy, L. N., Roy, R. N., Vogel, K. M.
+#    Pubname: Journal of Physical Chemistry
+#    Year: 1992
+#    Volume: 96
+#    Page: 11065
+#    Doi: 10.1021/j100205a081
+#    Puburl: http://pubs.acs.org/doi/abs/10.1021/j100205a081
+
+# ROZ/BER2011
+#    Type: Article
+#    Language: English
+#    Title: Solubility and thermodynamic properties of carbonate-bearing hydrotalcite–pyroaurite solid solutions with a 3:1 Mg/(Al+Fe) mole ratio
+#    Author: Berner, U., Diamond, L. W., Kulik, D. A., Rozov, K.
+#    Pubname: Clays and Clay Minerals
+#    Year: 2011
+#    Volume: 59
+#    Page: 215-232
+#    Doi: 10.1346/CCMN.2011.0590301
+
+# SAN/OTE2019
+#    Type: Article
+#    Language: English
+#    Title: Pressure and Temperature Effects on Low-Density Mg3Ca(CO3)4 Huntite Carbonate
+#    Author: Chulia-Jordan, R., MacLeod, S., Marqueño, T., Otero-de-la-Roza, A., Popescu, C., Ruiz-Fuertes, J., Santamaria-Perez, D.
+#    Pubname: Journal of Physical Chemistry C
+#    Year: 2019
+#    Volume: 124(1)
+#    Page: 1077-1087
+#    Publisher: American Chemical Society ({ACS})
+#    Doi: 10.1021/acs.jpcc.9b08952
+
+# SCH/MUN2012
+#    Type: Article
+#    Language: English
+#    Title: Activity Coefficients of Fission Products in Highly Salinary Solutions of Na+, K+, Mg2+, Ca2+, Cl–, and SO42–: Cs+
+#    Author: Moog, H. C., Munoz, A. G., Scharge, T.
+#    Pubname: Journal of Chemical and Engineering Data
+#    Year: 2012
+#    Volume: 57
+#    Page: 1637-1647
+#    Doi: 10.1021/je200970v
+
+# SCH/MUN2013
+#    Type: Article
+#    Language: English
+#    Title: Addition to "Activity Coefficients of Fission Products in Highly Salinary Solutions of Na+, K+, Mg2+, Ca2+, Cl–, and SO42–: Cs+"
+#    Author: Moog, H. C., Munoz, A. G., Scharge, T.
+#    Pubname: Journal of Chemical and Engineering Data
+#    Year: 2013
+#    Volume: 58
+#    Page: 187-188
+#    Doi: 10.1021/je301289a
+
+# SCH/MUN2013a
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamic modelling of high salinary phosphate solutions. I. Binary systems
+#    Author: Moog, H. C., Munoz, A. G., Scharge, T.
+#    Pubname: Journal of Chemical Thermodynamics
+#    Year: 2013
+#    Volume: 64
+#    Page: 249-256
+#    Doi: 10.1016/j.jct.2013.05.013
+
+# SCH/MUN2015
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamic modeling of high salinary phosphate solutions. II. Ternary and higher systems
+#    Author: Moog, H. C., Munoz, A. G., Scharge, T.
+#    Pubname: Journal of Chemical Thermodynamics
+#    Year: 2015
+#    Volume: 80
+#    Page: 172-183
+#    Doi: 10.1016/j.jct.2013.12.017
+
+# SCH/PAS2011
+#    Type: Article
+#    Language: English
+#    Title: Water channel structure of bassanite at high air humidity: crystal structure of CaSO4·0.625H2O
+#    Author: Freyer, D., Paschke, I., Schmidt, H., Voigt, W.
+#    Pubname: Acta Crystallographica, Section B: Structural Science
+#    Year: 2011
+#    Volume: 67(6)
+#    Page: 467-475
+#    Publisher: International Union of Crystallography ({IUCr})
+#    Doi: 10.1107/s0108768111041759
+
+# SCH/SEN1985
+#    Type: Article
+#    Language: English
+#    Title: Refinement of the structure of carnallite, Mg(H2O)6KCl3
+#    Author: Schlemper, E. O., Sen Gupta, P. K., Zoltai, T.
+#    Pubname: American Mineralogist
+#    Year: 1985
+#    Volume: 70(11-12)
+#    Page: 1309-1313
+
+# SCH2016
+#    Type: THEREDA-Report
+#    Language: English
+#    Title: Thermodynamic model for the systems Sr – Na, K, Mg, Ca – Cl, SO4 –H2O at 298.15 K
+#    Author: Scharge, T.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2016
+
+# SCH2017
+#    Type: THEREDA-Report
+#    Language: English
+#    Title: Thermodynamic database for phosphate, THEREDA Technical Paper Edition: 1.0
+#    Author: Scharge, T.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2017
+
+# SEB/POT2001
+#    Type: Article
+#    Language: English
+#    Title: A critical review of thermodynamic data for selenium species at 25°C
+#    Author: Borge, G., Donard, O. F. X., Giffaut, E., Potin-Gautier, M., Seby, F.
+#    Pubname: Chemical Geology
+#    Year: 2001
+#    Volume: 171
+#    Page: 173-194
+#    Doi: 10.1016/S0009-2541(00)00246-1
+#    Puburl: http://www.sciencedirect.com/science/article/pii/S0009254100002461
+
+# SHA/SZY2016
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamic studies of zippeite, a uranyl sulfate common in mine wastes
+#    Author: Burns, P. C., Fein, J. B., Navrotsky, A., Sharifironizi, M., Sigmon, G. E., Szymanowski, J. E. S.
+#    Pubname: Chemical Geology
+#    Year: 2016
+#    Volume: 447
+#    Page: 54-58
+#    Doi: 10.1016/j.chemgeo.2016.10.022
+
+# SHV/MAZ2011
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamic characterization of boltwoodite and uranophane: Enthalpy of formation and aqueous solubility
+#    Author: Burns, P. C., Fein, J. B., Gorman-Lewis, D., Mazeina, L., Navrotsky, A., Shvareva, T. Y., Szymanowski, J. E. S.
+#    Pubname: Geochimica et Cosmochimica Acta
+#    Year: 2011
+#    Volume: 18
+#    Page: 5269-5282
+#    Doi: 10.1016/j.gca.2011.06.041
+#    Puburl: http://www.sciencedirect.com/science/article/pii/S0016703711003796
+
+# SIL/BID1995
+#    Type: Book
+#    Language: English
+#    Title: Chemical Thermodynamics Vol. 2. Chemical Thermodynamics of Americium
+#    Author: Bidoglio, G., Puigdomenech, I., Rand, M. H., Robouch, P. B., Silva, R. J., Wanner, H.
+#    Pubname: not applicable because source is not a journal
+#    Year: 1995
+#    Page: 374
+#    Publisher: Elsevier Science Publ.
+#    Location: North-Holland. Amsterdam
+
+# SOH2020
+#    Type: THEREDA-Journal
+#    Language: English
+#    Title: Calcium Hydroxide Chlorides:  Correction of phase stoichiometries
+#    Author: Sohr, J.
+#    Pubname: THEREDA Journal
+#    Year: 2020
+
+# STE/GAN1984
+#    Type: Contribution to Proceeding
+#    Language: English
+#    Title: The use of cadmium ion-selective electrode and voltammetric techniques in the study of cadmium complexes with inorganic ligands
+#    Author: Borroni, P. A., Ganzerli Valentini, M. T., Stella, R.
+#    Pubname: not applicable because source is not a journal
+#    Year: 1984
+#    Page: 633-645
+#    Edition: 4th
+#    Location: Mátrafüired
+
+# STE/HOO1944
+#    Type: Article
+#    Language: English
+#    Title: The heat capacity of potassium dihydrogen phosphate from 15 to 300K. The anomaly at the curie temperature
+#    Author: Hooley, J. G., Stephenson, C. C.
+#    Pubname: Journal of the American Chemical Society
+#    Year: 1944
+#    Volume: 66
+#    Page: 1397-1401
+#    Doi: 10.1021/ja01236a054
+#    Puburl: https://pubs.acs.org/doi/abs/10.1021/ja01236a054
+
+# SUG/DIN2007a
+#    Type: Article
+#    Language: English
+#    Title: Structure determination of Mg3(OH)5Cl·4H2O (F5 phase) from laboratory powder diffraction data and its impact on the analysis of problematic magnesia floors
+#    Author: Dinnebier, R. E., Schlecht, T., Sugimoto, K.
+#    Pubname: Acta Crystallographica, Section B: Structural Science
+#    Year: 2007
+#    Volume: 63(6)
+#    Page: 805-811
+#    Doi: 10.1107/s0108768107046654
+
+# SZE/MES2016
+#    Type: Article
+#    Language: English
+#    Title: First experimental determination of the solubility constant of coffinite
+#    Author: Brau, H.-P., Clavier, N., Cordara, T., Dacheux, N., Ewing, R. C., LeGoff, X., Mesbah, A., Poinssot, C., Szenknect, S.
+#    Pubname: Geochimica et Cosmochimica Acta
+#    Year: 2016
+#    Volume: 181
+#    Page: 36-53
+#    Publisher: Elsevier
+#    Doi: 10.1016/j.gca.2016.02.010
+
+# TAL/BAL2020
+#    Type: Article
+#    Language: English
+#    Title: Structural and spectroscopic study of the kieserite-dwornikite solid-solution series, (Mg,Ni)SO4·H2O, at ambient and low temperatures, with cosmochemical implications for icy moons and Mars
+#    Author: Aicher, C., Balla, M., Lengauer, C. L., Talla, D., Wildner, M.
+#    Pubname: American Mineralogist
+#    Year: 2020
+#    Volume: 105(10)
+#    Page: 1472-1489
+#    Publisher: Mineralogical Society of America
+#    Doi: 10.2138/am-2020-7287
+
+# TAY/GAR1963
+#    Type: Report
+#    Language: English
+#    Title: Thermodynamic properties of cesium chloride and cesium iodide from 0 to 300 K
+#    Author: Gardner, T. E., Smith, D. F., Taylor Jr., A. R.
+#    Pubname: not applicable because source is not a journal
+#    Year: 1963
+#    Doi: 10.2172/4719514
+#    Puburl: https://www.osti.gov/biblio/4719514
+#    Location: Washington, DC
+
+# VIZ/GAR1999
+#    Type: Article
+#    Language: English
+#    Title: Na2Mg(SO4)2·4H2O, the Mg end-member of the bloedite-type of mineral
+#    Author: Garcia-Gonzalez, M. T., Vizcayno, C.
+#    Pubname: Acta Crystallographica, Section C: Crystal Structure Communications
+#    Year: 1999
+#    Volume: 55(1)
+#    Page: 8-11
+#    Doi: 10.1107/s0108270198011135
+
+# VOC/VAN1991
+#    Type: Article
+#    Language: German
+#    Title: Transformation of chernikovite into parsonite and study of its solubility product
+#    Author: Van Haverbeke, L., Van Springel, K., Vochten, R.
+#    Pubname: Neues Jahrbuch für Mineralogie, Monatshefte
+#    Year: 1991
+#    Volume: 12
+#    Page: 551-558
+#    Puburl: https://hdl.handle.net/10067/1030770151162165141
+
+# VOI/SUK2011
+#    Type: THEREDA-Report
+#    Language: English
+#    Title: Thermodynamic standard functions for pure water
+#    Author: Sukhanov, D., Voigt, W.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2011
+
+# VOI2020
+#    Type: THEREDA-Journal
+#    Language: English
+#    Title: Hexary System of Oceanic Salts – Polythermal Pitzer Dataset (numerical supplement)
+#    Author: Voigt, W.
+#    Pubname: THEREDA Journal
+#    Year: 2020
+#    Volume: 1(1)
+#    Page: 1-9
+#    Publisher: THEREDA
+#    Puburl: https://nbn-resolving.org/urn:nbn:de:bsz:105-qucosa2-782361
+#    Location: Freiberg
+
+# VOI2020a
+#    Type: THEREDA-Journal
+#    Language: English
+#    Title: Temperature extension of NaCl Pitzer coefficients and ∆RG°(NaCl)
+#    Author: Voigt, W.
+#    Pubname: THEREDA Journal
+#    Year: 2020
+#    Volume: 1(2)
+#    Page: 1-6
+#    Publisher: THEREDA
+#    Puburl: https://nbn-resolving.org/urn:nbn:de:bsz:105-qucosa2-782374
+#    Location: Freiberg
+
+# VOI2020b
+#    Type: THEREDA-Journal
+#    Language: English
+#    Title: An improved ∆RG°(D’Ansite)
+#    Author: Voigt, W.
+#    Pubname: THEREDA Journal
+#    Year: 2020
+#    Volume: 1
+
+# VOI2023
+#    Type: THEREDA-Journal
+#    Language: English
+#    Title: Implementation of Carbonates and CO2 into the T-dependent Pitzer Model of Oceanic Systems. I. System NaOH-Mg(OH)2-Ca(OH)2-CO2-H2O
+#    Author: Voigt, W.
+#    Pubname: THEREDA Journal
+#    Year: 2023
+#    Volume: 03(02)
+
+# WAG/EVA1982
+#    Type: Book
+#    Language: English
+#    Title: The NBS tables of chemical thermodynamic properties: Selected values for inorganic and C1 and C2 organic substances in SI units
+#    Author: Bailey, S. M., Churney, K. L., Evans, W. H., Halow, I., Nuttall, R. L., Parker, V. B., Schumm, R. H., Wagman, D. D.
+#    Pubname: not applicable because source is not a journal
+#    Year: 1982
+#    Volume: 11. Suppl. 2
+#    Page: 1-392
+#    Publisher: American Chemical Society
+
+# WAT/STA1967
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamic investigation of diorder in the hydrates of disodium hydrogen phosphate
+#    Author: Staveley, L. A. K., Waterfield, C. G.
+#    Pubname: Transactions of the Faraday Society
+#    Year: 1967
+#    Volume: 63
+#    Page: 2349-2356
+#    Doi: 10.1039/TF9676302349
+
+# WES/WER1981
+#    Type: Article
+#    Language: English
+#    Title: X-Ray Investigations of Ammines of Alkaline Earth Metal Halides. I. The Structures of CaCl2(NH3)8, CaCl2(NH3)2 and the Decomposition Product CaClOH.
+#    Author: Raldow, W., Schuler, T., Werner, P.-E., Westman, S.
+#    Pubname: Acta Chemica Scandinavica
+#    Year: 1981
+#    Volume: 35a
+#    Page: 467-472
+#    Doi: 10.3891/acta.chem.scand.35a-0467
+
+# WIE2006
+#    Type: Article
+#    Language: English
+#    Title: Atomic weights of the elements 2005 (IUPAC Technical Report)
+#    Author: Wieser, M. E.
+#    Pubname: Pure and Applied Chemistry
+#    Year: 2006
+#    Volume: 78(11)
+#    Page: 2051-2066
+#    Publisher: IUPAC
+#    Doi: 10.1351/pac200678112051
+#    Puburl: http://iupac.org/publications/pac/78/11/2051/
+
+# WIL2013
+#    Type: Report
+#    Language: English
+#    Title: Polythermal thermodynamic data set for cement minerals and their reaction products THEREDA II - Final Report
+#    Author: Wilhelm, S.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2013
+#    Page: 117
+#    Publisher: THEREDA
+
+# YAL/CEV2019
+#    Type: Article
+#    Language: English
+#    Title: Solubility of U(VI) in chloride solutions. III. The stable oxides/hydroxides in MgCl2 systems: Pitzer activity model for the system UO22+-Na+-K+- Mg2+-H+-OH--Cl--H2O(l)
+#    Author: Altmaier, M., Cevirim-Papaioannou, N., Fellhauer, D., Gaona, X., Neck, V., Yalcintas, E.
+#    Pubname: Journal of Chemical Thermodynamics
+#    Year: 2019
+#    Volume: 131
+#    Page: 375-386
+#    Doi: 10.1016/j.jct.2018.10.019
+
+# YAL/GAO2016
+#    Type: Article
+#    Language: English
+#    Title: Thermodynamic description of Tc(IV) solubility and hydrolysis in dilute to concentrated NaCl, MgCl2 and CaCl2 solutions
+#    Author: Altmaier, M., Dardenne, K., Gaona, X., Geckeis, H., Polly, R., Yalcintas, E.
+#    Pubname: Journal of the Chemical Society, Dalton Transactions
+#    Year: 2016
+#    Volume: 45
+#    Page: 8916-8936
+#    Doi: 10.1039/c6dt00973e
+
+# YAN/CEV2023
+#    Type: Contribution to Proceeding
+#    Language: English
+#    Title: Solubility and hydrolysis of U(IV) in dilute to concentrated NaCl, MgCl2 and CaCl2 systems: Pitzer modelling and implications for cement systems
+#    Author: Altmaier, M., Cevirim-Papaioannou, N., Dardenne, K., Fellhauer, D., Gaona, X., Geckeis, H., Yalcintas, E., Yan, Y.
+#    Pubname: not applicable because source is not a journal
+#    Year: 2023
+#    Location: Prague (Czech Republic)
+
+# YOU/BAT1981
+#    Type: Book
+#    Language: English
+#    Title: IUPAC Solubility Data Series: Hydrogen and Deuterium
+#    Author: Battino, R., Clever, H. L., Wiesenburg, D. A., Young, C. L.
+#    Editors: Young, C. L.
+#    Pubname: not applicable because source is not a journal
+#    Year: 1981
+#    Volume: 5/6
+#    Page: 646
+#    Publisher: Pergamon Press
+#    Puburl: http://srdata.nist.gov/solubility/IUPAC/SDS-5-6/SDS-5-6.pdf
+#    Location: Oxford
+
+# ZAL/RUB1964
+#    Type: Article
+#    Language: English
+#    Title: The crystal structure and hydrogen bonding of magnesium sulfate hexahydrate
+#    Author: Ruben, H., Templeton, D. H., Zalkin, A.
+#    Pubname: Acta Crystallographica
+#    Year: 1964
+#    Volume: 17(3)
+#    Page: 235-240
+#    Publisher: International Union of Crystallography ({IUCr})
+#    Doi: 10.1107/s0365110x64000603
+
+# #### list of editors #########################################################
+# Bok, Helmholtz-Zentrum Dresden-Rossendorf, Institute for Resource Ecology, Dep. for Surface Processes, P.O.Box 51 01 19, D-01314 Dresden, Germany
+# Freyer, TU Bergakademie Freiberg, Institute for Inorganic Chemistry, Arbeitsgruppe Salz-, Mineral- und Baustoffchemie, Akademiestrae 6, 09599 Freiberg, Germany
+# Gaona, Karlsruher Institut fuer Technologie, Institute for Nuclear Waste Disposal, Dep. for Radiochemistry, Hermann-von-Helmholtz-Platz 1, 76344 Eggenstein-Leopoldshafen, Germany
+# Kiefer, Karlsruher Institut fuer Technologie, Institute for Nuclear Waste Disposal, Dep. for Radiochemistry, Hermann-von-Helmholtz-Platz 1, 76344 Eggenstein-Leopoldshafen, Germany
+# Marquardt, Karlsruher Institut fuer Technologie, Institute for Nuclear Waste Disposal, Dep. for Radiochemistry, Hermann-von-Helmholtz-Platz 1, 76344 Eggenstein-Leopoldshafen, Germany
+# Miron, Paul Scherrer Institut, Waste Management Laboratory, 5232 Villigen, Switzerland
+# Moog, Gesellschaft fuer Anlagen- und Reaktorsicherheit, Dep. for Repository Research, Theodor-Heuss-Str. 4, 38122 Braunschweig, Germany
+# Richter, Helmholtz-Zentrum Dresden-Rossendorf, Institute for Resource Ecology, Dep. for Surface Processes, P.O.Box 51 01 19, D-01314 Dresden, Germany
+
+# #### evaluation data quality #################################################
+# -1: Internally calculated
+# 0: By definition / convention fixed value
+# 1: Reliable datum
+# 2: Datum is reliable within the given range of error, but error is relatively high (because of experimental problems, errors in utilized auxiliary data, or uncertainties due to unappropriate analogy-data or methods of estimation)
+# 3: Questionable value (uncertain model for speciation, uncertain auxiliary data), but nevertheless suitable and necessary for the description of experimental data in the system of interest
+# 4: Suitability for modelling or correctness not yet determined
+# 5: Scrutinized and deemed inapplicable for modeling (due to experimental shortcomings or inadequate assumptions in the course of processing experimental data or inadequate estimation procedures)
+# 6: Data quality not yet entered (to be done)
+
+# #### evaluation data class ###################################################
+# -1: Internally calculated with CalcMode CR, CGHR or CRLOG
+# 0: By definition / convention fixed value
+# 1: Value based upon experimental equilibrium data in aqueous solution
+# 2: Chemical analogue value, based upon experimental equilibrium data in aqueous solution
+# 3: Estimated value, based upon founded correlations and models for reaction data
+# 4: Origin of value not reported; data class cannot be determined
+# 5: Not consistent with other data in THEREDA
+# 6: Data class not yet entered (to be done)
+
+# #### evaluation ip class #####################################################
+# -1: Internally calculated with CalcMode CTPFUNC
+# 0: By definition / convention fixed value
+# 1: Value based upon experimental equilibrium data
+# 2: Chemical analogue value, based upon experimental equilibrium data
+# 3: Estimated value, based upon founded correlations and models
+# 4: Tentative value for unknown interaction coefficients which cannot be estimated
+# 5: Not consistent with other data in THEREDA
+# 6: IPClass not yet entered (to be done)
+
+# #### calculation modes #######################################################
+# CF: Calculated from formation data (DFG298, DFH298, or S298) of the reactants
+# CGHF: Gibbs-Helmholtz-Relation (formation): DFG298 = DFH298 - T*DFS298. (DFS298 not saved in the databank but calculated internally)
+# CGHR: Gibbs-Helmholtz-Relation (reaction): DRG298 = DRH298 - T DRS298
+# CR: Calculated from formation and reaction data of all other reactants
+# CRHO: Calculation of molar volume in cm3 mol-1 from density in g cm-3
+# CRLOGK: Calculated with -RT ln(10) LOGK298
+# CRLOGKT: Calculation of 298K data from LOGKT function
+# CTPFUNC: Calculated from temperature-/pressure function
+# CV: Calculation of density in g cm-3 from molar volume in cm3 mol-1
+# CXTERMEXTRAP: Calculation of LOGKT with DRCP298, DRH298, DRS298
+# CXTERMEXTRAP2: Calculation of LOGKT using LOGK298, DRH298, and DRCP298
+# Entered: Value has not been internally calculated but rather directly taken from the literature.
+
+# #### Licence #################################################################
+# The THEREDA team provides the compiled data to the widest possible circle of users. Therefore, we have decided to publish the data under the Creative Commons license (CC BY-NC-ND 4.0, https://creativecommons.org/licenses/by-nc-nd/4.0/deed.en).
+# You may use the data and distribute it according to this license under the following conditions:
+# Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
+# NonCommercial — You may not use the material for commercial purposes. A commercial use is primarily intended at commercial advantage or monetary compensation.
+# No Derivatives — If you remix, transform, or build upon the material, you may not distribute the modified material.
+# No additional restrictions — You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.
+# More information and the full legal code can be found here: 
+# https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode
+
+# #### Citation ################################################################
+# For the citation of THEREDA please use:
+# THEREDA -- Thermodynamic Reference Database, Release 2026, https://www.thereda.de
+
+END


### PR DESCRIPTION
This PR adds the Thermodynamic Reference Database (THEREDA) Release 2026-01 for PHREEQC as it is available on [the THEREDA project website](https://www.thereda.de/en/).

Major changes or additions compared to the former release are:
- Na+ – K+ – Mg2+ – Ca2+ – Cl- – SO42- – NO3- – H2O(l): binary and ternary systems (25 °C)
- M(III) – Na+ – Mg2+ – Ca2+ – H+ – Cl- – NO3- – OH- – H2O(l) (M = Am, Cm, Nd) (25 °C)
- Cd2+ – Na+ – K+ – Mg2+ – Ca2+ – Cl- – SO42- – CO32- – H2O(l): binary and ternary systems (25 °C)
- Na+ – Mg2+ – Ca2+ – OH- – CO32- – H2O(l) (polythermal, 25 °C – 100 °C)
- Molar volumes of solid phases, and alkalinity of solution master species were added for PHREEQC

